### PR TITLE
Video recording and xaml inclusion in  the nuget package

### DIFF
--- a/nuget/Plugin.nuspec
+++ b/nuget/Plugin.nuspec
@@ -62,6 +62,10 @@
      <file src="src\Media.Plugin.Abstractions\bin\Release\Plugin.Media.Abstractions.dll" target="lib\wpa81\Plugin.Media.Abstractions.dll" />
      <file src="src\Media.Plugin.Abstractions\bin\Release\Plugin.Media.Abstractions.xml" target="lib\wpa81\Plugin.Media.Abstractions.xml" />
      <file src="src\Media.Plugin.Abstractions\bin\Release\Plugin.Media.Abstractions.pdb" target="lib\wpa81\Plugin.Media.Abstractions.pdb" />
+     <file src="src\Media.Plugin.Abstractions\bin\Release\CameraCaptureUI.xaml.cs" target="lib\wpa81\CameraCaptureUI.xaml.cs" />
+     <file src="src\Media.Plugin.Abstractions\bin\Release\CameraCaptureUI.xbf" target="lib\wpa81\CameraCaptureUI.xbf" />
+     <file src="src\Media.Plugin.Abstractions\bin\Release\CameraCaptureUiPage.xaml.cs" target="lib\wpa81\CameraCaptureUiPage.xaml.cs" />
+     <file src="src\Media.Plugin.Abstractions\bin\Release\CameraCaptureUiPage.xbf" target="lib\wpa81\CameraCaptureUiPage.xbf" />
 
 
      <!--WinStore-->

--- a/nuget/Plugin.nuspec
+++ b/nuget/Plugin.nuspec
@@ -62,10 +62,10 @@
      <file src="src\Media.Plugin.Abstractions\bin\Release\Plugin.Media.Abstractions.dll" target="lib\wpa81\Plugin.Media.Abstractions.dll" />
      <file src="src\Media.Plugin.Abstractions\bin\Release\Plugin.Media.Abstractions.xml" target="lib\wpa81\Plugin.Media.Abstractions.xml" />
      <file src="src\Media.Plugin.Abstractions\bin\Release\Plugin.Media.Abstractions.pdb" target="lib\wpa81\Plugin.Media.Abstractions.pdb" />
-     <file src="src\Media.Plugin.Abstractions\bin\Release\CameraCaptureUI.xaml.cs" target="lib\wpa81\CameraCaptureUI.xaml.cs" />
-     <file src="src\Media.Plugin.Abstractions\bin\Release\CameraCaptureUI.xbf" target="lib\wpa81\CameraCaptureUI.xbf" />
-     <file src="src\Media.Plugin.Abstractions\bin\Release\CameraCaptureUiPage.xaml.cs" target="lib\wpa81\CameraCaptureUiPage.xaml.cs" />
-     <file src="src\Media.Plugin.Abstractions\bin\Release\CameraCaptureUiPage.xbf" target="lib\wpa81\CameraCaptureUiPage.xbf" />
+     <file src="src\Media.Plugin.WindowsPhone81\bin\Release\CameraCaptureUI.xaml.cs" target="lib\wpa81\CameraCaptureUI.xaml.cs" />
+     <file src="src\Media.Plugin.WindowsPhone81\bin\Release\CameraCaptureUI.xbf" target="lib\wpa81\CameraCaptureUI.xbf" />
+     <file src="src\Media.Plugin.WindowsPhone81\bin\Release\CameraCaptureUiPage.xaml.cs" target="lib\wpa81\CameraCaptureUiPage.xaml.cs" />
+     <file src="src\Media.Plugin.WindowsPhone81\bin\Release\CameraCaptureUiPage.xbf" target="lib\wpa81\CameraCaptureUiPage.xbf" />
 
 
      <!--WinStore-->

--- a/src/Media.Plugin.WindowsPhone81/CameraCaptureUI.xaml
+++ b/src/Media.Plugin.WindowsPhone81/CameraCaptureUI.xaml
@@ -15,7 +15,7 @@
         </Grid.RowDefinitions>
         <CaptureElement Grid.Row="0" Name="myCaptureElement" Stretch="UniformToFill"  ></CaptureElement>
         <StackPanel Grid.Row="1" Background="Transparent">
-            <AppBarButton VerticalAlignment="Center" HorizontalAlignment="Center"
+            <AppBarButton x:Name="camerButton" VerticalAlignment="Center" HorizontalAlignment="Center"
                        Click="Button_Click"  Icon="Camera" ></AppBarButton>
         </StackPanel >
     </Grid>


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes # .

Changes Proposed in this pull request:
- Add video recording modifying the XAML pages to include video option WP8.1
- Implement video recording in MediaImplementation.cs WP8.1
- Update plugin.nuspec to include xaml pages due to an XAMLParseException in Windows Phone 8.1
