### PR TITLE
Spelling correction and renamed function calls

### DIFF
--- a/component/GettingStarted.md
+++ b/component/GettingStarted.md
@@ -64,13 +64,13 @@ Via a Xamarin.Forms project with a Button and Image to take a photo:
       takePhoto.Clicked += async (sender, args) =>
         {
 
-          if (!CrossMedia.Current.IsCameraAvailable || !CrossMedia.Current.PhotosSupported)
+          if (!CrossMedia.Current.IsCameraAvailable || !CrossMedia.Current.IsTakePhotosSupported)
           {
-            DisplayAlert("No Camera", ":( No camera avaialble.", "OK");
+            DisplayAlert("No Camera", ":( No camera available.", "OK");
             return;
           }
 
-          var file = await CrossMedia.Current.TakePhotoAsync(new Media.Plugin.Abstractions.StoreCameraMediaOptions
+          var file = await CrossMedia.Current.TakePhotoAsync(new Plugin.Media.Abstractions.StoreCameraMediaOptions
             {
 
               Directory = "Sample",


### PR DESCRIPTION
Changes Proposed in this pull request:
- _“available”_ spelling error
- **Media.Plugin**.Abstractions should read **Plugin.Media.**Abstractions
- _CrossMeda.Current.PhotoSupported_ now reads _CrossMedia.Current.**IsTake**PhotoSupported

