### PR TITLE
#69 Updated readme to reflect iOS 10 requirement to add info.plist keys for NSCameraUsageDescription and NSPhotoLibraryUsageDescription.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ By adding these permissions [Google Play will automatically filter out devices](
 
 **iOS** 
 
-The library will automatically ask for permission when taking photos/videos or access the libraries.
+Since iOS 10, your app is required to have keys for NSCameraUsageDescription and NSPhotoLibraryUsageDescription in order to access the device's camera and photo library, respectively. Without these keys, your app will be likely to crash with a very unhelpful stack trace. The string that you provide for each of these keys will be displayed to the user when they are prompted to provide permission to access these device features.
 
 **Windows Phone 8/8.1 Silverlight:**
 


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes #69 .

Changes Proposed in this pull request:
- Updated readme to reflect iOS 10 changes that require apps to register for Camera and Photo Library permissions