### PR TITLE
Changes the behaviour of TakeMediaAsync to throw exceptions

### DIFF
--- a/src/Media.Plugin.Android/MediaImplementation.cs
+++ b/src/Media.Plugin.Android/MediaImplementation.cs
@@ -365,9 +365,9 @@ namespace Plugin.Media
                     return;
 
                 if (e.Error != null)
-                    tcs.SetResult(null);
+                    tcs.SetException(e.Error);
                 else if (e.IsCanceled)
-                    tcs.SetResult(null);
+                    tcs.SetCanceled();
                 else
                     tcs.SetResult(e.Media);
             };


### PR DESCRIPTION
Changes Proposed in this pull request:

Current implementation of Android's TakeMediaAsync returns null when user cancels the operation or an unexpected exception is thrown.
With the actual behaviour it's impossible to predict when user canceled the operation, an error occurred or null was returned by another reason.

Since we are awaiting a Task, in my point of view the expected behaviour should be:
1. Throw an OperationCancelledException when users closes the gallery;
2. Throw the exception which caused the error, when an unexpected exception occurs.

This fixes/implements:
- [x] Bug

Which plugin does this impact:
- [X] Media
