### PR TITLE
Give the exif data back to pictures

### DIFF
--- a/src/Media.Plugin.Abstractions/Location.cs
+++ b/src/Media.Plugin.Abstractions/Location.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Plugin.Media.Abstractions
+{
+    public struct Location
+    {
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
+        public double Altitude { get; set; }
+        public double HorizontalAccuracy { get; set; }
+        public double Speed { get; set; }
+        public double Direction { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/src/Media.Plugin.Abstractions/Media.Plugin.Abstractions.csproj
+++ b/src/Media.Plugin.Abstractions/Media.Plugin.Abstractions.csproj
@@ -36,6 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="IMedia.cs" />
+    <Compile Include="Location.cs" />
     <Compile Include="MediaExtensions.cs" />
     <Compile Include="MediaFile.cs" />
     <Compile Include="MediaFileNotFoundException.cs" />

--- a/src/Media.Plugin.Abstractions/MediaStoreOptions.cs
+++ b/src/Media.Plugin.Abstractions/MediaStoreOptions.cs
@@ -223,6 +223,10 @@ namespace Plugin.Media.Abstractions
             }
         }
 
+        /// <summary>
+        /// Store provided location
+        /// </summary>
+        public Location Location { get; set; }
     }
 
     /// <summary>

--- a/src/Media.Plugin.Abstractions/MediaStoreOptions.cs
+++ b/src/Media.Plugin.Abstractions/MediaStoreOptions.cs
@@ -122,6 +122,13 @@ namespace Plugin.Media.Abstractions
                     quality = value;
             }
         }
+
+        bool rotateImage = true;
+        /// <summary>
+        /// Should the library rotate image according to received exif orientation.
+        /// Set to true by default.
+        /// </summary>
+        public bool RotateImage { get { return rotateImage; } set { rotateImage = value;} }
     }
 
     
@@ -227,7 +234,14 @@ namespace Plugin.Media.Abstractions
         /// Store provided location
         /// </summary>
         public Location Location { get; set; }
-    }
+
+        bool rotateImage = true;
+        /// <summary>
+        /// Should the library rotate image according to received exif orientation.
+        /// Set to true by default.
+        /// </summary>
+        public bool RotateImage { get { return rotateImage; } set { rotateImage = value; } }
+}
 
     /// <summary>
     /// Photo size enum.

--- a/src/Media.Plugin.Android/MediaImplementation.cs
+++ b/src/Media.Plugin.Android/MediaImplementation.cs
@@ -39,7 +39,10 @@ namespace Plugin.Media
     [Android.Runtime.Preserve(AllMembers = true)]
     public class MediaImplementation : IMedia
     {
-        /// <summary>
+		const string TAG_PIXEL_X_DIMENSION = "PixelXDimension";
+		const string TAG_PIXEL_Y_DIMENSION = "PixelYDimension";
+
+		/// <summary>
         /// Implementation
         /// </summary>
         public MediaImplementation()
@@ -93,12 +96,11 @@ namespace Plugin.Media
 
                     if (options.RotateImage)
                     {
-						//await FixOrientationAndResizeAsync(media.Path, options);
-						await FixOrientationAndResizeAsync(media.Path, options.PhotoSize, options.CompressionQuality, options.CustomPhotoSize, originalMetadata);
+                        await FixOrientationAndResizeAsync(media.Path, options, originalMetadata);
                     }
                     else
                     {
-                        await ResizeAsync(media.Path, options.PhotoSize, options.CompressionQuality, options.CustomPhotoSize);
+                        await ResizeAsync(media.Path, options.PhotoSize, options.CompressionQuality, options.CustomPhotoSize, originalMetadata);
                     }
                     originalMetadata.SaveAttributes();
                 }
@@ -187,15 +189,14 @@ namespace Plugin.Media
 
             try
             {
-                //await FixOrientationAndResizeAsync(media.Path, options);
                 var exif = new ExifInterface(media.Path);
                 if (options.RotateImage)
                 {
-                    await FixOrientationAndResizeAsync(media.Path, options.PhotoSize, options.CompressionQuality, options.CustomPhotoSize, exif);
+                    await FixOrientationAndResizeAsync(media.Path, options, exif);
                 }
                 else
                 {
-                    await ResizeAsync(media.Path, options.PhotoSize, options.CompressionQuality, options.CustomPhotoSize);
+                    await ResizeAsync(media.Path, options.PhotoSize, options.CompressionQuality, options.CustomPhotoSize, exif);
                 }
                 SetMissingMetadata(exif, options.Location);
                 exif.SaveAttributes();
@@ -204,7 +205,6 @@ namespace Plugin.Media
             {
                 Console.WriteLine("Unable to check orientation: " + ex);
             }
-            
 
             return media;
         }
@@ -461,6 +461,7 @@ namespace Plugin.Media
         /// </summary>
         /// <param name="filePath">The file image path</param>
         /// <param name="mediaOptions">The options.</param>
+        /// <param name="exif">original metadata</param>
         /// <returns>True if rotation or compression occured, else false</returns>
         public Task<bool> FixOrientationAndResizeAsync(string filePath, PickMediaOptions mediaOptions, ExifInterface exif)
         {
@@ -481,6 +482,7 @@ namespace Plugin.Media
         /// </summary>
         /// <param name="filePath">The file image path</param>
         /// <param name="mediaOptions">The options.</param>
+        /// <param name="exif">original metadata</param>
         /// <returns>True if rotation or compression occured, else false</returns>
         public Task<bool> FixOrientationAndResizeAsync(string filePath, StoreCameraMediaOptions mediaOptions, ExifInterface exif)
         {
@@ -551,6 +553,17 @@ namespace Plugin.Media
                         {
                             originalImage = Bitmap.CreateScaledBitmap(originalImage, finalWidth, finalHeight, true);
                         }
+                        if (rotation % 180 == 90)
+                        {
+                            var a = finalWidth;
+                            finalWidth = finalHeight;
+                            finalHeight = a;
+                        }
+
+                        //set scaled and rotated image dimensions
+                        exif.SetAttribute(TAG_PIXEL_X_DIMENSION, Java.Lang.Integer.ToString(finalWidth));
+                        exif.SetAttribute(TAG_PIXEL_Y_DIMENSION, Java.Lang.Integer.ToString(finalHeight));
+
                         //if we need to rotate then go for it.
                         //then compresse it if needed
                         if (rotation != 0)
@@ -559,7 +572,6 @@ namespace Plugin.Media
                             matrix.PostRotate(rotation);
                             using (var rotatedImage = Bitmap.CreateBitmap(originalImage, 0, 0, originalImage.Width, originalImage.Height, matrix, true))
                             {
-                                    
                                 //always need to compress to save back to disk
                                 using (var stream = File.Open(filePath, FileMode.Create, FileAccess.ReadWrite))
                                 {
@@ -568,26 +580,19 @@ namespace Plugin.Media
                                 }
                                 rotatedImage.Recycle();
                             }
-                            originalImage.Recycle();
-                            originalImage.Dispose();
-                            // Dispose of the Java side bitmap.
-                            GC.Collect();
-
                             //change the orienation to "not rotated"
                             exif.SetAttribute(ExifInterface.TagOrientation, Java.Lang.Integer.ToString((int)Orientation.Normal));
-                            return true;
+
                         }
-
-                            
-
-                        //always need to compress to save back to disk
-                        using (var stream = File.Open(filePath, FileMode.Create, FileAccess.ReadWrite))
+                        else
                         {
-                            originalImage.Compress(Bitmap.CompressFormat.Jpeg, mediaOptions.CompressionQuality, stream);
-                            stream.Close();
+                            //always need to compress to save back to disk
+                            using (var stream = File.Open(filePath, FileMode.Create, FileAccess.ReadWrite))
+                            {
+                                originalImage.Compress(Bitmap.CompressFormat.Jpeg, mediaOptions.CompressionQuality, stream);
+                                stream.Close();
+                            }
                         }
-
-
 
                         originalImage.Recycle();
                         originalImage.Dispose();
@@ -648,8 +653,11 @@ namespace Plugin.Media
         /// </summary>
         /// <param name="filePath">The file image path</param>
         /// <param name="photoSize">Photo size to go to.</param>
+        /// <param name="quality">Image quality (1-100)</param>
+        /// <param name="customPhotoSize">Custom size in percent</param>
+        /// <param name="exif">original metadata</param>
         /// <returns>True if rotation or compression occured, else false</returns>
-        public Task<bool> ResizeAsync(string filePath, PhotoSize photoSize, int quality, int customPhotoSize)
+        public Task<bool> ResizeAsync(string filePath, PhotoSize photoSize, int quality, int customPhotoSize, ExifInterface exif)
         {
             if (string.IsNullOrWhiteSpace(filePath))
                 return Task.FromResult(false);
@@ -660,8 +668,6 @@ namespace Plugin.Media
                 {
                     try
                     {
-                        
-
                         if (photoSize == PhotoSize.Full)
                             return false;
 
@@ -694,6 +700,10 @@ namespace Plugin.Media
 
                         var finalWidth = (int)(options.OutWidth * percent);
                         var finalHeight = (int)(options.OutHeight * percent);
+
+                        //set scaled image dimensions
+                        exif.SetAttribute(TAG_PIXEL_X_DIMENSION, Java.Lang.Integer.ToString(finalWidth));
+                        exif.SetAttribute(TAG_PIXEL_Y_DIMENSION, Java.Lang.Integer.ToString(finalHeight));
 
                         //calculate sample size
                         options.InSampleSize = CalculateInSampleSize(options, finalWidth, finalHeight);
@@ -764,7 +774,7 @@ namespace Plugin.Media
             }
         }
 
-		private string coordinateToRational(double coord)
+        private string coordinateToRational(double coord)
         {
             coord = coord > 0 ? coord : -coord;
             int degrees = (int)coord;

--- a/src/Media.Plugin.Android/MediaImplementation.cs
+++ b/src/Media.Plugin.Android/MediaImplementation.cs
@@ -178,7 +178,10 @@ namespace Plugin.Media
             try
             {
                 //await FixOrientationAndResizeAsync(media.Path, options);
+                var exif = new ExifInterface(media.Path);
                 await ResizeAsync(media.Path, options.PhotoSize, options.CompressionQuality, options.CustomPhotoSize);
+                SetMissingMetadata(exif, options.Location);
+                exif.SaveAttributes();
             }
             catch(Exception ex)
             {
@@ -636,7 +639,6 @@ namespace Plugin.Media
         {
             if (string.IsNullOrWhiteSpace(filePath))
                 return Task.FromResult(false);
-            var exif = new ExifInterface(filePath);
 
             try
             {
@@ -699,7 +701,6 @@ namespace Plugin.Media
                             }
                             
                             originalImage.Recycle();
-                            exif.SaveAttributes();
 
                             // Dispose of the Java side bitmap.
                             GC.Collect();
@@ -740,6 +741,41 @@ namespace Plugin.Media
                 throw ex;
 #endif
             }
+        }
+
+        void SetMissingMetadata(ExifInterface exif, Location location)
+        {
+            Single[] position = new Single[6];
+            if (!exif.GetLatLong(position) && location.Latitude+location.Longitude > 0)
+            {
+                exif.SetAttribute(ExifInterface.TagGpsLatitude, coordinateToRational(location.Latitude));
+                exif.SetAttribute(ExifInterface.TagGpsLongitude, coordinateToRational(location.Longitude));
+                exif.SetAttribute(ExifInterface.TagGpsLatitudeRef, location.Latitude > 0 ? "N" : "S");
+                exif.SetAttribute(ExifInterface.TagGpsLongitudeRef, location.Longitude > 0 ? "E" : "W");
+            }
+            if (string.IsNullOrEmpty(exif.GetAttribute(ExifInterface.TagDatetime)))
+            {
+                exif.SetAttribute(ExifInterface.TagDatetime, DateTime.Now.ToString("yyyy:MM:dd hh:mm:ss"));
+            }
+            if (string.IsNullOrEmpty(exif.GetAttribute(ExifInterface.TagMake))) {
+                exif.SetAttribute(ExifInterface.TagMake, Build.Manufacturer);
+            }
+            if (string.IsNullOrEmpty(exif.GetAttribute(ExifInterface.TagModel)))
+            {
+                exif.SetAttribute(ExifInterface.TagModel, Build.Model);
+            }
+        }
+
+		private string coordinateToRational(double coord)
+        {
+            coord = coord > 0 ? coord : -coord;
+            int degrees = (int)coord;
+            coord = (coord % 1) * 60;
+            int minutes = (int)coord;
+            coord = (coord % 1) * 60000;
+            int sec = (int)coord;
+
+            return $"{degrees}/1,{minutes}/1,{sec}/1000";
         }
 
         static int GetRotation(string filePath)

--- a/src/Media.Plugin.Android/MediaImplementation.cs
+++ b/src/Media.Plugin.Android/MediaImplementation.cs
@@ -89,7 +89,8 @@ namespace Plugin.Media
             {
                 try
                 {
-                    await FixOrientationAndResizeAsync(media.Path, options);
+                    //await FixOrientationAndResizeAsync(media.Path, options);
+                    await ResizeAsync(media.Path, options.PhotoSize, options.CompressionQuality, options.CustomPhotoSize);
                 }
                 catch (Exception ex)
                 {
@@ -173,9 +174,11 @@ namespace Plugin.Media
 
             //check to see if we need to rotate if success
 
+
             try
             {
-                await FixOrientationAndResizeAsync(media.Path, options);
+                //await FixOrientationAndResizeAsync(media.Path, options);
+                await ResizeAsync(media.Path, options.PhotoSize, options.CompressionQuality, options.CustomPhotoSize);
             }
             catch(Exception ex)
             {
@@ -462,6 +465,7 @@ namespace Plugin.Media
         {
             if (string.IsNullOrWhiteSpace(filePath))
                 return Task.FromResult(false);
+            var originalMetadata = new ExifInterface(filePath);
 
             try
             {
@@ -553,7 +557,7 @@ namespace Plugin.Media
                             GC.Collect();
 
                             //Save out new exif data
-                            SetExifData(filePath, Orientation.Normal);
+                            SetExifData(originalMetadata, Orientation.Normal);
                             return true;
                         }
 
@@ -632,6 +636,7 @@ namespace Plugin.Media
         {
             if (string.IsNullOrWhiteSpace(filePath))
                 return Task.FromResult(false);
+            var exif = new ExifInterface(filePath);
 
             try
             {
@@ -694,6 +699,7 @@ namespace Plugin.Media
                             }
                             
                             originalImage.Recycle();
+                            exif.SaveAttributes();
 
                             // Dispose of the Java side bitmap.
                             GC.Collect();
@@ -721,16 +727,12 @@ namespace Plugin.Media
         }
 
 
-        void SetExifData(string filePath, Orientation orientation)
+        void SetExifData(ExifInterface originalMetadata, Orientation orientation)
         {
             try
             {
-                using (var ei = new ExifInterface(filePath))
-                {
-
-                    ei.SetAttribute(ExifInterface.TagOrientation, Java.Lang.Integer.ToString((int)orientation));
-                    ei.SaveAttributes();                    
-                }
+                originalMetadata.SetAttribute(ExifInterface.TagOrientation, Java.Lang.Integer.ToString((int)orientation));
+                originalMetadata.SaveAttributes();                    
             }
             catch (Exception ex)
             {

--- a/src/Media.Plugin.iOS/Media.Plugin.iOS.csproj
+++ b/src/Media.Plugin.iOS/Media.Plugin.iOS.csproj
@@ -45,6 +45,7 @@
     <Compile Include="NSDataStream.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UIImageExtensions.cs" />
+    <Compile Include="PhotoLibraryAccess.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Media.Plugin.Abstractions\Media.Plugin.Abstractions.csproj">

--- a/src/Media.Plugin.iOS/MediaPickerDelegate.cs
+++ b/src/Media.Plugin.iOS/MediaPickerDelegate.cs
@@ -353,6 +353,9 @@ namespace Plugin.Media
 
                     //begin resizing image
                     image = image.ResizeImageWithAspectRatio(width, height);
+                    //update exif pixel dimiensions
+                    meta[ImageIO.CGImageProperties.ExifDictionary].SetValueForKey(new NSString(width.ToString()), ImageIO.CGImageProperties.ExifPixelXDimension);
+                    meta[ImageIO.CGImageProperties.ExifDictionary].SetValueForKey(new NSString(height.ToString()), ImageIO.CGImageProperties.ExifPixelYDimension);
 
                 }
                 catch (Exception ex)

--- a/src/Media.Plugin.iOS/PhotoLibraryAccess.cs
+++ b/src/Media.Plugin.iOS/PhotoLibraryAccess.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using CoreImage;
+using Foundation;
+using Photos;
+
+namespace Plugin.Media
+{
+	public static class PhotoLibraryAccess
+	{
+		public static NSDictionary GetPhotoLibraryMetadata(NSUrl url)
+		{
+			NSDictionary meta = null;
+
+			var image = PHAsset.FetchAssets(new NSUrl[] { url }, new PHFetchOptions()).firstObject as PHAsset;
+			var imageManager = PHImageManager.DefaultManager;
+			var requestOptions = new PHImageRequestOptions
+			{
+				Synchronous = true,
+				NetworkAccessAllowed = true,
+				DeliveryMode = PHImageRequestOptionsDeliveryMode.HighQualityFormat,
+			};
+			imageManager.RequestImageData(image, requestOptions, (data, dataUti, orientation, info) =>
+			{
+				try
+				{
+					var fullimage = CIImage.FromData(data);
+					if (fullimage?.Properties != null)
+					{
+						meta = new NSMutableDictionary();
+						meta[ImageIO.CGImageProperties.Orientation] = new NSString(fullimage.Properties.Orientation.ToString());
+						meta[ImageIO.CGImageProperties.ExifDictionary] = fullimage.Properties.Exif?.Dictionary ?? new NSDictionary();
+						meta[ImageIO.CGImageProperties.TIFFDictionary] = fullimage.Properties.Tiff?.Dictionary ?? new NSDictionary();
+						meta[ImageIO.CGImageProperties.GPSDictionary] = fullimage.Properties.Gps?.Dictionary ?? new NSDictionary();
+						meta[ImageIO.CGImageProperties.IPTCDictionary] = fullimage.Properties.Iptc?.Dictionary ?? new NSDictionary();
+						meta[ImageIO.CGImageProperties.JFIFDictionary] = fullimage.Properties.Jfif?.Dictionary ?? new NSDictionary();
+					}
+				}
+				catch (Exception ex)
+				{
+					Console.WriteLine(ex);
+				}
+
+			});
+
+			return meta;
+		}
+	}
+}


### PR DESCRIPTION
They were not written (iOS) to file or destroyed (Android) with FixOrientationAndResizeAsync. I have reverted back to ResizeAsync as I think the library should not do that. It should be app duty to rotate picture where needed, and library should be transparent.

Fixes #184 #185 

Changes Proposed in this pull request:
- store exif data on both iOS and Android, and not let it destroyed when resizing
- extract exif on iOS when photo is selected from gallery
- do not rotate pictures anymore - give to app what it receives from camera
- allow write the gps location to exif, as on iOS and some Android phones it is not available from camera
