### PR TITLE
[Windows Phone 8.1] Set TakePhotoAsync theme to Dark to fix #223

### DIFF
--- a/src/Media.Plugin.WindowsPhone81/CameraCaptureUI.xaml
+++ b/src/Media.Plugin.WindowsPhone81/CameraCaptureUI.xaml
@@ -15,7 +15,7 @@
         </Grid.RowDefinitions>
         <CaptureElement Grid.Row="0" Name="myCaptureElement" Stretch="UniformToFill"  ></CaptureElement>
         <StackPanel Grid.Row="1" Background="Transparent">
-            <AppBarButton x:Name="camerButton" VerticalAlignment="Center" HorizontalAlignment="Center"
+            <AppBarButton x:Name="camerButton" VerticalAlignment="Center" HorizontalAlignment="Center" RequestedTheme="Dark"
                        Click="Button_Click"  Icon="Camera" ></AppBarButton>
         </StackPanel >
     </Grid>


### PR DESCRIPTION
Fixes issue #223 

Changes Proposed in this pull request:

Problem: The Camera icon's color responds to the theme set by the user, so, before this change, if the inherited theme is Light then the Camera icon's color becomes the same as the background's and is therefore invisible to the user.

Solution: Set the AppBarButton's theme to Dark so that it does not inherit the one set by the user.