### PR TITLE
Allow user to set max size limit on Android

### DIFF
--- a/src/Media.Plugin.Abstractions/MediaStoreOptions.cs
+++ b/src/Media.Plugin.Abstractions/MediaStoreOptions.cs
@@ -313,5 +313,16 @@ namespace Plugin.Media.Abstractions
             get;
             set;
         }
+
+        /// <summary>
+        /// Desired Video Size
+        /// Only available on Android - Set the desired file size in bytes.
+        /// Eg. 1000000 = 1MB
+        /// </summary>
+        public long DesiredSize
+        {
+            get;
+            set;
+        }
     }
 }

--- a/src/Media.Plugin.Android/MediaImplementation.cs
+++ b/src/Media.Plugin.Android/MediaImplementation.cs
@@ -293,6 +293,10 @@ namespace Plugin.Media
                     }
                     pickerIntent.PutExtra(MediaStore.ExtraDurationLimit, (int)vidOptions.DesiredLength.TotalSeconds);
                     pickerIntent.PutExtra(MediaStore.ExtraVideoQuality, (int)vidOptions.Quality);
+                    if (vidOptions.DesiredSize != 0)
+                    {
+                        pickerIntent.PutExtra(MediaStore.ExtraSizeLimit, vidOptions.DesiredSize);
+                    }
                 }
             }
             //pickerIntent.SetFlags(ActivityFlags.ClearTop);


### PR DESCRIPTION
Added a property on the Video options that will allow a user to specify
the maximum size limit in bytes.

Please take a moment to fill out the following:

Fixes # .New functionality

Changes Proposed in this pull request:
- Allows users on Android to limit the video size in bytes
-
- 
