### PR TITLE
scale image with orientation on iOS

### DIFF
--- a/src/Media.Plugin.iOS/MediaPickerDelegate.cs
+++ b/src/Media.Plugin.iOS/MediaPickerDelegate.cs
@@ -331,7 +331,7 @@ namespace Plugin.Media
                         newHeight = (image.CGImage.Height * percent);
 
                         //begin resizing image
-                        image = image.ResizeImageWithAspectRatio(newWidth, newHeight);
+                        image = image.ScaleImageWithOrientation(newWidth, newHeight);
                     }
                    
                 }

--- a/src/Media.Plugin.iOS/MediaPickerDelegate.cs
+++ b/src/Media.Plugin.iOS/MediaPickerDelegate.cs
@@ -350,7 +350,7 @@ namespace Plugin.Media
                     var height = (image.CGImage.Height * percent);
 
                     //begin resizing image
-                    image = image.ResizeImageWithAspectRatio(width, height);
+                    image = image.ScaleImageWithOrientation(width, height);
                     //update exif pixel dimiensions
                     meta[ImageIO.CGImageProperties.ExifDictionary].SetValueForKey(new NSString(width.ToString()), ImageIO.CGImageProperties.ExifPixelXDimension);
                     meta[ImageIO.CGImageProperties.ExifDictionary].SetValueForKey(new NSString(height.ToString()), ImageIO.CGImageProperties.ExifPixelYDimension);

--- a/src/Media.Plugin.iOS/UIImageExtensions.cs
+++ b/src/Media.Plugin.iOS/UIImageExtensions.cs
@@ -66,5 +66,39 @@ namespace Plugin.Media
             UIGraphics.EndImageContext();
             return modifiedImage;
         }
+
+        public static UIImage ScaleImageWithOrientation(this UIImage sourceImage, float width, float height)
+        {
+		    const float PI_2 = (float)(Math.PI / 2.0);
+            UIImage resultImage;
+
+            using (CGImage image = sourceImage.CGImage)
+            {
+                CGImageAlphaInfo alpha = image.AlphaInfo == CGImageAlphaInfo.None ? CGImageAlphaInfo.NoneSkipLast  : image.AlphaInfo;
+                CGColorSpace color = CGColorSpace.CreateDeviceRGB();
+                var bitmap = new CGBitmapContext(IntPtr.Zero, (int)width, (int)height, image.BitsPerComponent, image.BytesPerRow, color, alpha);
+                bitmap.DrawImage(new Rectangle(0, 0, (int)width, (int)height), image);
+
+                switch (sourceImage.Orientation)
+                {
+                    case UIImageOrientation.Left:
+                        bitmap.RotateCTM(PI_2);
+                        bitmap.TranslateCTM(0, -height);
+                        break;
+                    case UIImageOrientation.Right:
+                        bitmap.RotateCTM(-PI_2);
+                        bitmap.TranslateCTM(-width, 0);
+                        break;
+                    case UIImageOrientation.Down:
+                        bitmap.TranslateCTM(width, height);
+                        bitmap.RotateCTM(-(float)Math.PI);
+                        break;
+                }
+
+                resultImage = UIImage.FromImage(bitmap.ToImage());
+            }
+
+            return resultImage;
+        }
     }
 }


### PR DESCRIPTION
This PR fixes one problem I've found out recently - when app scales image down with `PhotoSize.xxx` it will receive image rotated on iOS. That seems to be caused by the fact that during rescale image is changing it's orientation but the original `Orientation` flag remains (and is read-only).

I've tried many approaches on setting the flag but only this solution worked for me.