### PR TITLE
Fix for an iOS bug where a TabbedPage will have it's height/padding c…

### DIFF
--- a/src/Media.Plugin.iOS/MediaImplementation.cs
+++ b/src/Media.Plugin.iOS/MediaImplementation.cs
@@ -274,7 +274,7 @@ namespace Plugin.Media
             {
                 if (UIDevice.CurrentDevice.CheckSystemVersion(9, 0))
                 {
-                    picker.ModalPresentationStyle = UIModalPresentationStyle.Fullscreen;
+                    picker.ModalPresentationStyle = UIModalPresentationStyle.FullScreen;
                 }
                 viewController.PresentViewController(picker, true, null);
             }

--- a/src/Media.Plugin.iOS/MediaImplementation.cs
+++ b/src/Media.Plugin.iOS/MediaImplementation.cs
@@ -274,7 +274,7 @@ namespace Plugin.Media
             {
                 if (UIDevice.CurrentDevice.CheckSystemVersion(9, 0))
                 {
-                    picker.ModalPresentationStyle = UIModalPresentationStyle.OverCurrentContext;
+                    picker.ModalPresentationStyle = UIModalPresentationStyle.Fullscreen;
                 }
                 viewController.PresentViewController(picker, true, null);
             }


### PR DESCRIPTION
Fix for an iOS bug where a TabbedPage will have it's height/padding changed after the media picker popover has been presented. It caused issues in our app at work, and the fix was to change the presentation style of the media picker popover to Fullscreen. Based on the description of issue #335, it should fix that as well.

Fixes #335.

Changes Proposed in this pull request:
- Bug fixed where the height/padding of the view controller is changed after the media picker popover is presented, due to the presentation style of OverCurrentContext.
