### PR TITLE
Fix orientation's value type stored in metadata

### DIFF
--- a/src/Media.Plugin.iOS/PhotoLibraryAccess.cs
+++ b/src/Media.Plugin.iOS/PhotoLibraryAccess.cs
@@ -36,7 +36,7 @@ namespace Plugin.Media
 					{
 						meta = new NSMutableDictionary
 						{
-							[ImageIO.CGImageProperties.Orientation] = new NSString(fullimage.Properties.Orientation.ToString()),
+							[ImageIO.CGImageProperties.Orientation] = NSNumber.FromNInt ((int)(fullimage.Properties.Orientation ?? CIImageOrientation.TopLeft)),
 							[ImageIO.CGImageProperties.ExifDictionary] = fullimage.Properties.Exif?.Dictionary ?? new NSDictionary(),
 							[ImageIO.CGImageProperties.TIFFDictionary] = fullimage.Properties.Tiff?.Dictionary ?? new NSDictionary(),
 							[ImageIO.CGImageProperties.GPSDictionary] = fullimage.Properties.Gps?.Dictionary ?? new NSDictionary(),


### PR DESCRIPTION
Fixes #333, #392 .

Changes Proposed in this pull request:
- Exif orientations must be an integer not a string https://developer.apple.com/documentation/imageio/kcgimagepropertyorientation