### PR TITLE
Workaround for issue #307

### DIFF
--- a/src/Media.Plugin.Android/IntentExtraExtensions.cs
+++ b/src/Media.Plugin.Android/IntentExtraExtensions.cs
@@ -1,0 +1,33 @@
+﻿using Android.Content;
+using Android.Hardware;
+
+namespace Plugin.Media
+{
+	internal static class IntentExtraExtensions
+	{
+		private const string extraFrontPre25 = "android.intent.extras.CAMERA_FACING";
+		private const string extraFrontPost25 = "android.intent.extras.LENS_FACING_FRONT";
+		private const string extraBackPost25 = "android.intent.extras.LENS_FACING_BACK";
+		private const string extraUserFront = "android.intent.extra.USE_FRONT_CAMERA";
+
+		public static void UseFrontCamera(this Intent intent)
+		{
+			// Android before API 25 (7.1)
+			intent.PutExtra(extraFrontPre25, (int)CameraFacing.Front);
+
+			// Android API 25 and up
+			intent.PutExtra(extraFrontPost25, 1);
+			intent.PutExtra(extraUserFront, true);
+		}
+
+		public static void UseBackCamera(this Intent intent)
+		{
+			// Android before API 25 (7.1)
+			intent.PutExtra(extraFrontPre25, (int)CameraFacing.Front);
+
+			// Android API 25 and up
+			intent.PutExtra(extraBackPost25, 1);
+			intent.PutExtra(extraUserFront, false);
+		}
+	}
+}

--- a/src/Media.Plugin.Android/Media.Plugin.Android.csproj
+++ b/src/Media.Plugin.Android/Media.Plugin.Android.csproj
@@ -70,6 +70,7 @@
     <Compile Include="..\Media.Plugin\CrossMedia.cs">
       <Link>CrossMedia.cs</Link>
     </Compile>
+    <Compile Include="IntentExtraExtensions.cs" />
     <Compile Include="MainApplication.cs" />
     <Compile Include="MediaFile.cs" />
     <Compile Include="MediaImplementation.cs" />

--- a/src/Media.Plugin.Android/MediaPickerActivity.cs
+++ b/src/Media.Plugin.Android/MediaPickerActivity.cs
@@ -131,7 +131,13 @@ namespace Plugin.Media
                     pickIntent.PutExtra(MediaStore.ExtraVideoQuality, GetVideoQuality(quality));
 
                     if (front != 0)
-                        pickIntent.PutExtra(ExtraFront, (int)Android.Hardware.CameraFacing.Front);
+                    {
+                        pickIntent.UseFrontCamera();
+                    }
+                    else
+                    {
+                        pickIntent.UseBackCamera();
+                    }
 
                     if (!ran)
                     {


### PR DESCRIPTION
The intent with extras for the front camera is dependent on the installed (system) camera app. Some of them support no selection of front/rear camera (e.g. Samsung A5 2017).
The workaround add known intent extras to handle the selection of camera facing.

Fixes #307 .

Changes Proposed in this pull request:
- extract setting front / back intent extras in extension method
- add known extras for camera facing manipulation
- add explizit setting of extras for the back camera (some camera apps store the last used facing)
  