### PR TITLE
Implemented possibility to save images in an album for iOS

### DIFF
--- a/src/Media.Plugin.Abstractions/MediaStoreOptions.cs
+++ b/src/Media.Plugin.Abstractions/MediaStoreOptions.cs
@@ -253,6 +253,11 @@ namespace Plugin.Media.Abstractions
 			get { return saveMetaData; }
 			set { saveMetaData = value; }
 		}
+
+		/// <summary>
+		/// The name of the Album in the Gallery.
+		/// </summary>
+		public string Album { get; set; }
 	}
 
     /// <summary>

--- a/src/Media.Plugin.Abstractions/MediaStoreOptions.cs
+++ b/src/Media.Plugin.Abstractions/MediaStoreOptions.cs
@@ -173,12 +173,20 @@ namespace Plugin.Media.Abstractions
         }
 
         /// <summary>
-        // Get or set if the image should be stored public
+        /// Get or set if the image should be stored public
         /// </summary>
         public bool SaveToAlbum
         {
             get; set;
         }
+
+		/// <summary>
+		/// Get or set the name of the album u wish to save your picture in.
+		/// </summary>
+		public string AlbumName
+		{
+			get; set;
+		}
 
         /// <summary>
         /// Gets or sets the size of the photo.
@@ -253,11 +261,6 @@ namespace Plugin.Media.Abstractions
 			get { return saveMetaData; }
 			set { saveMetaData = value; }
 		}
-
-		/// <summary>
-		/// The name of the Album in the Gallery.
-		/// </summary>
-		public string Album { get; set; }
 	}
 
     /// <summary>


### PR DESCRIPTION
I finally were able to implement it to save pictures in an album under iOS. This works not for videos but i guess it's very similar to implement.

Fixes #149 .

Changes Proposed in this pull request:
- Added a new property for the name of the album. If this is filled an album will be created. 
- Added function to get the album by the given album name.
- Added action to save the image.
- Creates the album if it doesn't exist.
