### PR TITLE
Fix NullReferenceException when picking Pictures from "My photo stream" in iOS 10.x

### DIFF
--- a/src/Media.Plugin.iOS/MediaPickerDelegate.cs
+++ b/src/Media.Plugin.iOS/MediaPickerDelegate.cs
@@ -67,6 +67,9 @@ namespace Plugin.Media
 
 			Dismiss(picker, () =>
 			{
+                if (mediaFile == null)
+                    tcs.SetException(new FileNotFoundException());
+                
 				tcs.TrySetResult(mediaFile);
 			});
 		}
@@ -269,6 +272,9 @@ namespace Plugin.Media
 		private async Task<MediaFile> GetPictureMediaFile(NSDictionary info)
 		{
 			var image = (UIImage)info[UIImagePickerController.EditedImage] ?? (UIImage)info[UIImagePickerController.OriginalImage];
+
+            if (image == null)
+                return;
 
 			var path = GetOutputPath(MediaImplementation.TypeImage,
 				options.Directory ?? ((IsCaptured) ? string.Empty : "temp"),

--- a/src/Media.Plugin.iOS/MediaPickerDelegate.cs
+++ b/src/Media.Plugin.iOS/MediaPickerDelegate.cs
@@ -69,8 +69,8 @@ namespace Plugin.Media
 			{
                 if (mediaFile == null)
                     tcs.SetException(new FileNotFoundException());
-                
-				tcs.TrySetResult(mediaFile);
+				else
+					tcs.TrySetResult(mediaFile);
 			});
 		}
 

--- a/src/Media.Plugin.iOS/MediaPickerDelegate.cs
+++ b/src/Media.Plugin.iOS/MediaPickerDelegate.cs
@@ -274,7 +274,7 @@ namespace Plugin.Media
 			var image = (UIImage)info[UIImagePickerController.EditedImage] ?? (UIImage)info[UIImagePickerController.OriginalImage];
 
             if (image == null)
-                return;
+                return null;
 
 			var path = GetOutputPath(MediaImplementation.TypeImage,
 				options.Directory ?? ((IsCaptured) ? string.Empty : "temp"),


### PR DESCRIPTION
Please take a moment to fill out the following:

In iOS 10.x currently we have the problem that the `var image = (UIImage)info[UIImagePickerController.EditedImage] ?? (UIImage)info[UIImagePickerController.OriginalImage];`is currently returning null and the code is crashing with NullReferenceException. This happens picking some images from the "My photo stream" folder.

Changes Proposed in this pull request:

This MR is handling this case and returning a FileNotFoundException in case of this happens. My guess is that the files are not really stored locally (the are only in iCloud), and locally we have just the reference to that files.
