### PR TITLE
Added iOS specific option for specifying the modal presentation style of the media picker

### DIFF
--- a/src/Media.Plugin.Abstractions/MediaStoreOptions.cs
+++ b/src/Media.Plugin.Abstractions/MediaStoreOptions.cs
@@ -48,6 +48,27 @@ namespace Plugin.Media.Abstractions
         Front
     }
 
+	/// <summary>
+	/// Specifies the media picker's modal presentation style.
+	/// Only applies to iOS.
+	/// </summary>
+	public enum MediaPickerModalPresentationStyle
+	{
+		/// <summary>
+		/// This is the equivalent of presenting the media picker with UIKit.UIModalPresentationStyle.FullScreen style.
+		/// Will remove the views of the underlying view controller when presenting the media picker.
+		/// Only applies to iOS.
+		/// </summary>
+		FullScreen,
+
+		/// <summary>
+		/// This is the equivalent of presenting the media picker with UIKit.UIModalPresentationStyle.OverFullScreen style.
+		/// Will keep the views of the underlying view controller when presenting the media picker.
+		/// Only applies to iOS.
+		/// </summary>
+		OverFullScreen
+	}
+
     /// <summary>
     /// 
     /// </summary>
@@ -127,7 +148,14 @@ namespace Plugin.Media.Abstractions
 			get { return saveMetaData; }
 			set { saveMetaData = value; }
 		}
-	}
+
+	    /// <summary>
+	    /// Specifies the media picker's modal presentation style.
+	    /// Only applies to iOS.
+	    /// Defaults to FullScreen, which is the equivalent of using UIKit.UIModalPresentationStyle.FullScreen.
+	    /// </summary>
+		public MediaPickerModalPresentationStyle ModalPresentationStyle { get; set; } = MediaPickerModalPresentationStyle.FullScreen;
+    }
 
     
 
@@ -253,6 +281,13 @@ namespace Plugin.Media.Abstractions
 			get { return saveMetaData; }
 			set { saveMetaData = value; }
 		}
+
+	    /// <summary>
+	    /// Specifies the media picker's modal presentation style.
+	    /// Only applies to iOS.
+	    /// Defaults to FullScreen, which is the equivalent of using UIKit.UIModalPresentationStyle.FullScreen.
+	    /// </summary>
+	    public MediaPickerModalPresentationStyle ModalPresentationStyle { get; set; } = MediaPickerModalPresentationStyle.FullScreen;
 	}
 
     /// <summary>

--- a/src/Media.Plugin.iOS/MediaImplementation.cs
+++ b/src/Media.Plugin.iOS/MediaImplementation.cs
@@ -93,6 +93,7 @@ namespace Plugin.Media
 				RotateImage = options?.RotateImage ?? true,
 				SaveMetaData = options?.SaveMetaData ?? true,
 				SaveToAlbum = false,
+				ModalPresentationStyle = options?.ModalPresentationStyle ?? MediaPickerModalPresentationStyle.FullScreen,
             };
 
             return await GetMediaAsync(UIImagePickerControllerSourceType.PhotoLibrary, TypeImage, cameraOptions);
@@ -284,7 +285,9 @@ namespace Plugin.Media
             {
                 if (UIDevice.CurrentDevice.CheckSystemVersion(9, 0))
                 {
-                    picker.ModalPresentationStyle = UIModalPresentationStyle.FullScreen;
+	                picker.ModalPresentationStyle = options?.ModalPresentationStyle == MediaPickerModalPresentationStyle.OverFullScreen
+		                ? UIModalPresentationStyle.OverFullScreen
+		                : UIModalPresentationStyle.FullScreen;
                 }
                 viewController.PresentViewController(picker, true, null);
             }


### PR DESCRIPTION
Changes Proposed in this pull request:

According to [View Controller Programming Guide on iOS](https://developer.apple.com/library/content/featuredarticles/ViewControllerPGforiPhoneOS/PresentingaViewController.html)

> When presenting a view controller using the UIModalPresentationFullScreen style, UIKit normally removes the views of the underlying view controller after the transition animations finish. You can prevent the removal of those views by specifying the UIModalPresentationOverFullScreen style instead. You might use that style when the presented view controller has transparent areas that let underlying content show through.

Removing the views of the underlying view controller can also have side effects on Xamarin Forms, specially when using a framework such as MVVMCross with a MvxMasterDetailPage, as its viewmodel's lifecycle gets triggered when returning from the Media Picker.

- This PR allows the user to choose the modal presentation style used when presenting the media picker on iOS.
- It defaults the modal presentation style to FullScreen so that the current behaviour will not be changed.
