### PR TITLE
Fix bug in image orientation logic on iOS

### DIFF
--- a/src/Media.Plugin/iOS/MediaPickerDelegate.cs
+++ b/src/Media.Plugin/iOS/MediaPickerDelegate.cs
@@ -734,6 +734,7 @@ namespace Plugin.Media
 
 			var stream = new MemoryStream();
 			imageData.AsStream().CopyTo(stream);
+			stream.Position = 0;
 			imageData.Dispose();
 			return stream;
 


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes #579 .

Changes Proposed in this pull request:
- reset stream location after copying so that data is not "lost"