### PR TITLE
Removed an unnecessary picker.Dispose()

### DIFF
--- a/src/Media.Plugin/iOS/MediaPickerDelegate.cs
+++ b/src/Media.Plugin/iOS/MediaPickerDelegate.cs
@@ -164,14 +164,6 @@ namespace Plugin.Media
 				else
 				{
 					picker.DismissViewController(true, onDismiss);
-					try
-					{
-						picker.Dispose();
-					}
-					catch
-					{
-
-					}
 				}
 			}
 		}


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes issue number #563.

Changes Proposed in this pull request:
- the picker controller was being disposed twice, and one of the two calls is actually before the picker is really dismissed. so I just removed that.