### PR TITLE
Fixed typo in exception message

### DIFF
--- a/src/Media.Plugin/iOS/MediaImplementation.cs
+++ b/src/Media.Plugin/iOS/MediaImplementation.cs
@@ -271,7 +271,7 @@ namespace Plugin.Media
             MediaPickerDelegate ndelegate = new MediaPickerDelegate(viewController, sourceType, options);
             var od = Interlocked.CompareExchange(ref pickerDelegate, ndelegate, null);
             if (od != null)
-                throw new InvalidOperationException("Only one operation can be active at at time");
+                throw new InvalidOperationException("Only one operation can be active at a time");
 
             var picker = SetupController(ndelegate, sourceType, mediaType, options);
 


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes # .

- NA

Changes Proposed in this pull request:

- Changed InvalidOperationException message from "Only one operation can be active at at time" to "Only one operation can be active at a time"
