### PR TITLE
Cancellation support

### DIFF
--- a/src/Media.Plugin/Android/MediaImplementation.cs
+++ b/src/Media.Plugin/Android/MediaImplementation.cs
@@ -82,7 +82,7 @@ namespace Plugin.Media
         /// Picks a photo from the default gallery
         /// </summary>
         /// <returns>Media file or null if canceled</returns>
-        public async Task<MediaFile> PickPhotoAsync(PickMediaOptions options = null)
+        public async Task<MediaFile> PickPhotoAsync(PickMediaOptions options = null, CancellationToken token = default(CancellationToken))
         {
             if (!(await RequestStoragePermission()))
             {
@@ -137,7 +137,7 @@ namespace Plugin.Media
         /// </summary>
         /// <param name="options">Camera Media Options</param>
         /// <returns>Media file of photo or null if canceled</returns>
-        public async Task<MediaFile> TakePhotoAsync(StoreCameraMediaOptions options)
+        public async Task<MediaFile> TakePhotoAsync(StoreCameraMediaOptions options, CancellationToken token = default(CancellationToken))
         {
             if (!IsCameraAvailable)
                 throw new NotSupportedException();
@@ -245,7 +245,7 @@ namespace Plugin.Media
         /// Picks a video from the default gallery
         /// </summary>
         /// <returns>Media file of video or null if canceled</returns>
-        public async Task<MediaFile> PickVideoAsync()
+        public async Task<MediaFile> PickVideoAsync(CancellationToken token = default(CancellationToken))
         {
 
             if (!(await RequestStoragePermission()))
@@ -261,7 +261,7 @@ namespace Plugin.Media
         /// </summary>
         /// <param name="options">Video Media Options</param>
         /// <returns>Media file of new video or null if canceled</returns>
-        public async Task<MediaFile> TakeVideoAsync(StoreVideoOptions options)
+        public async Task<MediaFile> TakeVideoAsync(StoreVideoOptions options, CancellationToken token = default(CancellationToken))
         {
             if (!IsCameraAvailable)
                 throw new NotSupportedException();
@@ -459,7 +459,7 @@ namespace Plugin.Media
             return id;
         }
 
-        private Task<MediaFile> TakeMediaAsync(string type, string action, StoreMediaOptions options)
+        private Task<MediaFile> TakeMediaAsync(string type, string action, StoreMediaOptions options, CancellationToken token = default(CancellationToken))
         {
             int id = GetRequestId();
 

--- a/src/Media.Plugin/Android/MediaPickerActivity.cs
+++ b/src/Media.Plugin/Android/MediaPickerActivity.cs
@@ -88,8 +88,9 @@ namespace Plugin.Media
         protected override void OnCreate(Bundle savedInstanceState)
         {
             base.OnCreate(savedInstanceState);
+	        MediaImplementation.CancelRequested += CancellationRequested;
 
-            var b = (savedInstanceState ?? Intent.Extras);
+			var b = (savedInstanceState ?? Intent.Extras);
 
             var ran = b.GetBoolean("ran", defaultValue: false);
 
@@ -218,7 +219,14 @@ namespace Plugin.Media
             }
         }
 
-        private void Touch()
+	    private void CancellationRequested(object sender, EventArgs e)
+	    {
+			FinishActivity(id);
+			DeleteOutputFile();
+			Finish();
+		}
+		
+		private void Touch()
         {
             if (path.Scheme != "file")
                 return;
@@ -332,9 +340,9 @@ namespace Plugin.Media
         protected override async void OnActivityResult(int requestCode, Result resultCode, Intent data)
         {
             completed = true;
+	        MediaImplementation.CancelRequested -= CancellationRequested;
             base.OnActivityResult(requestCode, resultCode, data);
-
-
+			
 
             if (tasked)
             {

--- a/src/Media.Plugin/Media.Plugin.csproj
+++ b/src/Media.Plugin/Media.Plugin.csproj
@@ -1,4 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras/1.6.47">
+<!--<Project Sdk="Microsoft.NET.Sdk">-->
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard1.0;netstandard2.0;MonoAndroid71;Xamarin.iOS10;uap10.0.10240;Tizen40</TargetFrameworks>

--- a/src/Media.Plugin/Shared/IMedia.cs
+++ b/src/Media.Plugin/Shared/IMedia.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Plugin.Media.Abstractions
@@ -36,31 +37,35 @@ namespace Plugin.Media.Abstractions
         /// </summary>
         bool IsPickVideoSupported { get; }
 
-        /// <summary>
-        /// Picks a photo from the default gallery
-        /// </summary>
-        /// <returns>Media file or null if canceled</returns>
-        Task<MediaFile> PickPhotoAsync(PickMediaOptions options = null);
+		/// <summary>
+		/// Picks a photo from the default gallery
+		/// </summary>
+		/// <param name="token">Cancellation token</param>
+		/// <returns>Media file or null if canceled</returns>
+		Task<MediaFile> PickPhotoAsync(PickMediaOptions options = null, CancellationToken token = default(CancellationToken));
 
-        /// <summary>
-        /// Take a photo async with specified options
-        /// </summary>
-        /// <param name="options">Camera Media Options</param>
-        /// <returns>Media file of photo or null if canceled</returns>
-        Task<MediaFile> TakePhotoAsync(StoreCameraMediaOptions options);
+	    /// <summary>
+	    /// Take a photo async with specified options
+	    /// </summary>
+	    /// <param name="options">Camera Media Options</param>
+	    /// <param name="token">Cancellation token</param>
+	    /// <returns>Media file of photo or null if canceled</returns>
+	    Task<MediaFile> TakePhotoAsync(StoreCameraMediaOptions options, CancellationToken token = default(CancellationToken));
 
-        /// <summary>
-        /// Picks a video from the default gallery
-        /// </summary>
-        /// <returns>Media file of video or null if canceled</returns>
-        Task<MediaFile> PickVideoAsync();
+		/// <summary>
+		/// Picks a video from the default gallery
+		/// </summary>
+		/// <param name="token">Cancellation token</param>
+		/// <returns>Media file of video or null if canceled</returns>
+		Task<MediaFile> PickVideoAsync(CancellationToken token = default(CancellationToken));
 
-        /// <summary>
-        /// Take a video with specified options
-        /// </summary>
-        /// <param name="options">Video Media Options</param>
-        /// <returns>Media file of new video or null if canceled</returns>
-        Task<MediaFile> TakeVideoAsync(StoreVideoOptions options);
+		/// <summary>
+		/// Take a video with specified options
+		/// </summary>
+		/// <param name="options">Video Media Options</param>
+		/// <param name="token">Cancellation token</param>
+		/// <returns>Media file of new video or null if canceled</returns>
+		Task<MediaFile> TakeVideoAsync(StoreVideoOptions options, CancellationToken token = default(CancellationToken));
 
-    }
+	}
 }

--- a/src/Media.Plugin/Tizen/MediaImplementation.cs
+++ b/src/Media.Plugin/Tizen/MediaImplementation.cs
@@ -73,8 +73,9 @@ namespace Plugin.Media
 		/// Take a photo async with specified options
 		/// </summary>
 		/// <param name="options">Camera Media Options</param>
+		/// <param name="token">Cancellation token (currently ignored)</param>
 		/// <returns>Media file of photo or null if canceled</returns>
-		public Task<MediaFile> TakePhotoAsync(StoreCameraMediaOptions options)
+		public Task<MediaFile> TakePhotoAsync(StoreCameraMediaOptions options, CancellationToken token = default(CancellationToken))
 		{
 			if (!IsCameraAvailable || !IsTakePhotoSupported)
 			{
@@ -96,8 +97,9 @@ namespace Plugin.Media
 		/// Take a video with specified options
 		/// </summary>
 		/// <param name="options">Video Media Options</param>
+		/// <param name="token">Cancellation token (currently ignored)</param>
 		/// <returns>Media file of new video or null if canceled</returns>
-		public Task<MediaFile> TakeVideoAsync(StoreVideoOptions options)
+		public Task<MediaFile> TakeVideoAsync(StoreVideoOptions options, CancellationToken token = default(CancellationToken))
 		{
 			if (!IsCameraAvailable || !IsTakeVideoSupported) {
 				Log.Error(LOG_TAG, "TakeVideo is not supported");
@@ -117,8 +119,9 @@ namespace Plugin.Media
 		/// <summary>
 		/// Picks a video from the default gallery
 		/// </summary>
+		/// <param name="token">Cancellation token (currently ignored)</param>
 		/// <returns>Media file of video or null if canceled</returns>
-		public Task<MediaFile> PickPhotoAsync(PickMediaOptions options = null)
+		public Task<MediaFile> PickPhotoAsync(PickMediaOptions options = null, CancellationToken token = default(CancellationToken))
 		{
 			if (!IsPickPhotoSupported)
 			{
@@ -139,8 +142,9 @@ namespace Plugin.Media
 		/// <summary>
 		/// Picks a video from the default gallery
 		/// </summary>
+		/// <param name="token">Cancellation token (currently ignored)</param>
 		/// <returns>Media file of video or null if canceled</returns>
-		public Task<MediaFile> PickVideoAsync()
+		public Task<MediaFile> PickVideoAsync(CancellationToken token = default(CancellationToken))
 		{
 			if (!IsPickVideoSupported)
 			{

--- a/src/Media.Plugin/UWP/MediaImplementation.cs
+++ b/src/Media.Plugin/UWP/MediaImplementation.cs
@@ -91,8 +91,9 @@ namespace Plugin.Media
         /// Take a photo async with specified options
         /// </summary>
         /// <param name="options">Camera Media Options</param>
+        /// <param name="token">Cancellation token (currently ignored)</param>
         /// <returns>Media file of photo or null if canceled</returns>
-        public async Task<MediaFile> TakePhotoAsync(StoreCameraMediaOptions options)
+        public async Task<MediaFile> TakePhotoAsync(StoreCameraMediaOptions options, CancellationToken token = default(CancellationToken))
         {
             if (!initialized)
                 await Initialize();
@@ -182,8 +183,9 @@ namespace Plugin.Media
         /// <summary>
         /// Picks a photo from the default gallery
         /// </summary>
+        /// <param name="token">Cancellation token (currently ignored)</param>
         /// <returns>Media file or null if canceled</returns>
-        public async Task<MediaFile> PickPhotoAsync(PickMediaOptions options = null)
+        public async Task<MediaFile> PickPhotoAsync(PickMediaOptions options = null, CancellationToken token = default(CancellationToken))
         {
             var picker = new FileOpenPicker();
             picker.SuggestedStartLocation = PickerLocationId.PicturesLibrary;
@@ -226,8 +228,9 @@ namespace Plugin.Media
         /// Take a video with specified options
         /// </summary>
         /// <param name="options">Video Media Options</param>
+        /// <param name="token">Cancellation token (currently ignored)</param>
         /// <returns>Media file of new video or null if canceled</returns>
-        public async Task<MediaFile> TakeVideoAsync(StoreVideoOptions options)
+        public async Task<MediaFile> TakeVideoAsync(StoreVideoOptions options, CancellationToken token = default(CancellationToken))
         {
             if (!initialized)
                 await Initialize();
@@ -271,8 +274,9 @@ namespace Plugin.Media
         /// <summary>
         /// Picks a video from the default gallery
         /// </summary>
+        /// <param name="token">Cancellation token (currently ignored)</param>
         /// <returns>Media file of video or null if canceled</returns>
-        public async Task<MediaFile> PickVideoAsync()
+        public async Task<MediaFile> PickVideoAsync(CancellationToken token = default(CancellationToken))
         {
 			var picker = new FileOpenPicker()
 			{

--- a/src/Media.Plugin/iOS/MediaImplementation.cs
+++ b/src/Media.Plugin/iOS/MediaImplementation.cs
@@ -268,7 +268,9 @@ namespace Plugin.Media
             while (viewController.PresentedViewController != null)
                 viewController = viewController.PresentedViewController;
 
-            MediaPickerDelegate ndelegate = new MediaPickerDelegate(viewController, sourceType, options);
+	        if (token.IsCancellationRequested) return Task.FromResult((MediaFile) null);
+
+            MediaPickerDelegate ndelegate = new MediaPickerDelegate(viewController, sourceType, options, token);
             var od = Interlocked.CompareExchange(ref pickerDelegate, ndelegate, null);
             if (od != null)
                 throw new InvalidOperationException("Only one operation can be active at a time");
@@ -290,7 +292,7 @@ namespace Plugin.Media
 		                : UIModalPresentationStyle.FullScreen;
                 }
                 viewController.PresentViewController(picker, true, null);
-            }
+			}
 
             return ndelegate.Task.ContinueWith(t =>
             {

--- a/src/Media.Plugin/iOS/MediaImplementation.cs
+++ b/src/Media.Plugin/iOS/MediaImplementation.cs
@@ -69,7 +69,7 @@ namespace Plugin.Media
         /// Picks a photo from the default gallery
         /// </summary>
         /// <returns>Media file or null if canceled</returns>
-        public async Task<MediaFile> PickPhotoAsync(PickMediaOptions options = null)
+        public async Task<MediaFile> PickPhotoAsync(PickMediaOptions options = null, CancellationToken token = default(CancellationToken))
         {
             if (!IsPickPhotoSupported)
                 throw new NotSupportedException();
@@ -96,7 +96,7 @@ namespace Plugin.Media
 				ModalPresentationStyle = options?.ModalPresentationStyle ?? MediaPickerModalPresentationStyle.FullScreen,
             };
 
-            return await GetMediaAsync(UIImagePickerControllerSourceType.PhotoLibrary, TypeImage, cameraOptions);
+            return await GetMediaAsync(UIImagePickerControllerSourceType.PhotoLibrary, TypeImage, cameraOptions, token);
         }
 
 
@@ -105,7 +105,7 @@ namespace Plugin.Media
         /// </summary>
         /// <param name="options">Camera Media Options</param>
         /// <returns>Media file of photo or null if canceled</returns>
-        public async Task<MediaFile> TakePhotoAsync(StoreCameraMediaOptions options)
+        public async Task<MediaFile> TakePhotoAsync(StoreCameraMediaOptions options, CancellationToken token = default(CancellationToken))
         {
             if (!IsTakePhotoSupported)
                 throw new NotSupportedException();
@@ -124,7 +124,7 @@ namespace Plugin.Media
 
 			await CheckPermissions(permissionsToCheck.ToArray());
 
-            return await GetMediaAsync(UIImagePickerControllerSourceType.Camera, TypeImage, options);
+            return await GetMediaAsync(UIImagePickerControllerSourceType.Camera, TypeImage, options, token);
         }
 
 
@@ -132,7 +132,7 @@ namespace Plugin.Media
         /// Picks a video from the default gallery
         /// </summary>
         /// <returns>Media file of video or null if canceled</returns>
-        public async Task<MediaFile> PickVideoAsync()
+        public async Task<MediaFile> PickVideoAsync(CancellationToken token = default(CancellationToken))
         {
             if (!IsPickVideoSupported)
                 throw new NotSupportedException();
@@ -147,7 +147,7 @@ namespace Plugin.Media
 				await CheckPermissions(Permission.Photos);
 			}
 
-			var media = await GetMediaAsync(UIImagePickerControllerSourceType.PhotoLibrary, TypeMovie);
+			var media = await GetMediaAsync(UIImagePickerControllerSourceType.PhotoLibrary, TypeMovie, token: token);
 
             UIApplication.SharedApplication.EndBackgroundTask(backgroundTask);
 
@@ -160,7 +160,7 @@ namespace Plugin.Media
         /// </summary>
         /// <param name="options">Video Media Options</param>
         /// <returns>Media file of new video or null if canceled</returns>
-        public async Task<MediaFile> TakeVideoAsync(StoreVideoOptions options)
+        public async Task<MediaFile> TakeVideoAsync(StoreVideoOptions options, CancellationToken token = default(CancellationToken))
         {
             if (!IsTakeVideoSupported)
                 throw new NotSupportedException();
@@ -180,7 +180,7 @@ namespace Plugin.Media
 
 			await CheckPermissions(permissionsToCheck.ToArray());
 
-            return await GetMediaAsync(UIImagePickerControllerSourceType.Camera, TypeMovie, options);
+            return await GetMediaAsync(UIImagePickerControllerSourceType.Camera, TypeMovie, options, token);
         }
 
         private UIPopoverController popover;
@@ -245,7 +245,7 @@ namespace Plugin.Media
             return picker;
         }
 
-        private Task<MediaFile> GetMediaAsync(UIImagePickerControllerSourceType sourceType, string mediaType, StoreCameraMediaOptions options = null)
+        private Task<MediaFile> GetMediaAsync(UIImagePickerControllerSourceType sourceType, string mediaType, StoreCameraMediaOptions options = null, CancellationToken token = default(CancellationToken))
         {
 			
 			UIViewController viewController = null;

--- a/src/Media.Plugin/iOS/MediaPickerDelegate.cs
+++ b/src/Media.Plugin/iOS/MediaPickerDelegate.cs
@@ -34,6 +34,7 @@ namespace Plugin.Media
 
 			token.Register(() =>
 			{
+				// The continuation attached to this Task in MediaImplementaiton will close the UI.
 				tcs.SetResult(null);
 			});
 		}

--- a/src/Media.Plugin/iOS/MediaPickerDelegate.cs
+++ b/src/Media.Plugin/iOS/MediaPickerDelegate.cs
@@ -13,12 +13,14 @@ using System.Globalization;
 using ImageIO;
 using MobileCoreServices;
 using System.Drawing;
+using System.Threading;
 
 namespace Plugin.Media
 {
 	internal class MediaPickerDelegate : UIImagePickerControllerDelegate
 	{
-		internal MediaPickerDelegate(UIViewController viewController, UIImagePickerControllerSourceType sourceType, StoreCameraMediaOptions options)
+		internal MediaPickerDelegate(UIViewController viewController, UIImagePickerControllerSourceType sourceType,
+			StoreCameraMediaOptions options, CancellationToken token)
 		{
 			this.viewController = viewController;
 			source = sourceType;
@@ -29,6 +31,11 @@ namespace Plugin.Media
 				UIDevice.CurrentDevice.BeginGeneratingDeviceOrientationNotifications();
 				observer = NSNotificationCenter.DefaultCenter.AddObserver(UIDevice.OrientationDidChangeNotification, DidRotate);
 			}
+
+			token.Register(() =>
+			{
+				tcs.SetResult(null);
+			});
 		}
 
 		public UIPopoverController Popover


### PR DESCRIPTION
No issue raised.  PR for discussion as to whether this is something you'd like include or not.

For some context, the app I'm working on requires the user to log in as the data they have access to may be sensitive.  The app logs out after a period of inactivity.  We have an issue if the user goes inactive while the camera is open - we need to close the camera/gallery in this scenario without user interaction.

Changes Proposed in this pull request:

- Add optional CancellationToken parameter to the public API, to allow the camera/gallery UI to be closed directly, not just through user input.

Currently I've only implemented for iOS and Droid, that's all I need for now, but I'm happy to go the rest of the way if you want to take this on board.