### PR TITLE
Fix for LG phone crashes when using camera

### DIFF
--- a/src/Media.Plugin/Android/IntentExtraExtensions.cs
+++ b/src/Media.Plugin/Android/IntentExtraExtensions.cs
@@ -28,11 +28,15 @@ namespace Plugin.Media
 			// Android API 25 and up
 			intent.PutExtra(extraBackPost25, 1);
 
+			//Removed PutExtra.  LG Phones crash when setting this intent and the back camera
+			// is already enabled (UserFront=false)
+
 			//TODO: Test if we can use the GetExtra to check before setting. May still fix LG
-			//with less potential negative side-effects 
+			//with less potential negative side-effects for other phones or for the front-facing camera
+			
 			//var val = intent.GetBooleanExtra(extraUserFront, false);
 			//if (val)
-				intent.PutExtra(extraUserFront, false);
+			//	intent.PutExtra(extraUserFront, false);
 		}
 	}
 }

--- a/src/Media.Plugin/Android/IntentExtraExtensions.cs
+++ b/src/Media.Plugin/Android/IntentExtraExtensions.cs
@@ -28,15 +28,9 @@ namespace Plugin.Media
 			// Android API 25 and up
 			intent.PutExtra(extraBackPost25, 1);
 
-			//Removed PutExtra.  LG Phones crash when setting this intent and the back camera
-			// is already enabled (UserFront=false)
-
-			//TODO: Test if we can use the GetExtra to check before setting. May still fix LG
-			//with less potential negative side-effects for other phones or for the front-facing camera
-			
-			//var val = intent.GetBooleanExtra(extraUserFront, false);
-			//if (val)
-			//	intent.PutExtra(extraUserFront, false);
+			var val = intent.GetBooleanExtra(extraUserFront, false);
+			if (val)
+				intent.PutExtra(extraUserFront, false);
 		}
 	}
 }

--- a/src/Media.Plugin/Android/IntentExtraExtensions.cs
+++ b/src/Media.Plugin/Android/IntentExtraExtensions.cs
@@ -27,7 +27,12 @@ namespace Plugin.Media
 
 			// Android API 25 and up
 			intent.PutExtra(extraBackPost25, 1);
-			intent.PutExtra(extraUserFront, false);
+
+			//TODO: Test if we can use the GetExtra to check before setting. May still fix LG
+			//with less potential negative side-effects 
+			//var val = intent.GetBooleanExtra(extraUserFront, false);
+			//if (val)
+				intent.PutExtra(extraUserFront, false);
 		}
 	}
 }


### PR DESCRIPTION
Some LG phones (LG v30 for sure) crash when setting the android.intent.extra.USE_FRONT_CAMERA extra to false when it is already false.

Please take a moment to fill out the following:

Fixes # .

Changes Proposed in this pull request:
- Check that the extra is not true before actually setting to false. This solves the issue in all cases and does not break when switching between front and rear cameras.