### PR TITLE
Bugfix iOS crashes from memory issues

### DIFF
--- a/src/Media.Plugin/iOS/MediaPickerDelegate.cs
+++ b/src/Media.Plugin/iOS/MediaPickerDelegate.cs
@@ -407,6 +407,7 @@ namespace Plugin.Media
 
 				imageData.Save(path, true);
 				imageData.Dispose();
+				
 			}
 
 
@@ -474,6 +475,7 @@ namespace Plugin.Media
 			{
 				var finalQuality = quality;
 				var imageData = image.AsJPEG(finalQuality);
+
 				//continue to move down quality , rare instances
 				while (imageData == null && finalQuality > 0)
 				{
@@ -540,7 +542,10 @@ namespace Plugin.Media
 				if (success)
 				{
 					imageWithExif.Save(path, true);
+					imageWithExif.Dispose();
+					imageWithExif = null;
 				}
+				
 				return success;
 
 			}
@@ -761,6 +766,8 @@ namespace Plugin.Media
 			imageData.AsStream().CopyTo(stream);
 			stream.Position = 0;
 			imageData.Dispose();
+			image.Dispose();
+			image = null;
 			return stream;
 
 		}

--- a/src/Media.Plugin/iOS/MediaPickerDelegate.cs
+++ b/src/Media.Plugin/iOS/MediaPickerDelegate.cs
@@ -615,18 +615,29 @@ namespace Plugin.Media
 			return Path.Combine(path, nname);
 		}
 
-		internal static string GetOutputPath(string type, string path, string name)
+		internal static string GetOutputPath(string type, string path, string name, long index = 0)
 		{
 			path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), path);
 			Directory.CreateDirectory(path);
 
+			var epoch = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+			var postpendName = index == 0 ? string.Empty : $"{index}";
+			postpendName += Math.Abs(epoch);
 			if (string.IsNullOrWhiteSpace(name))
 			{
-				var timestamp = DateTime.Now.ToString("yyyMMdd_HHmmss", CultureInfo.InvariantCulture);
 				if (type == MediaImplementation.TypeImage)
-					name = "IMG_" + timestamp + ".jpg";
+					name = $"IMG_{postpendName}.jpg";
 				else
-					name = "VID_" + timestamp + ".mp4";
+					name = $"VID_{postpendName}.mp4";
+			}
+			else
+			{
+				var namePart = name.Split(".");
+				name = $"{namePart[0]}_{postpendName}";
+				if(namePart.Length > 1)
+				{
+					name = name + namePart[1];
+				}
 			}
 
 			return Path.Combine(path, GetUniquePath(type, path, name));


### PR DESCRIPTION
Please take a moment to fill out the following:

Hey James, Clinton Rocksmith here.  Manbir is a member of my team and we use your plugin.  We would love you to merge it in and do a Nuget alpha release so we can further test it and contribute.

Fixes # .
Fixes a crash where many images can be selected (15+) and it will cause the plugin to crash as it runs out of memory.

Changes Proposed in this pull request:
- Fixed issue where Images were not recycling and not disposed of.  The root cause of the memory issue.
- Improved speed by using Parallel.For to speed up processing of images.
