### PR TITLE
Fixed Android NullReferenceExcepiton on canceling/dismissing PickPhotosAsync.

### DIFF
--- a/src/Media.Plugin/Android/MediaImplementation.cs
+++ b/src/Media.Plugin/Android/MediaImplementation.cs
@@ -122,6 +122,9 @@ namespace Plugin.Media
 
 			var medias = await TakeMediasAsync("image/*", Intent.ActionPick, new StorePickerMediaOptions { MultiPicker = true }, token);
 
+			if (medias == null)
+				return null;
+
 			if (options == null)
 				options = new PickMediaOptions();
 


### PR DESCRIPTION
This pull request fixes Android part of issue #666. Fix #649 (and mentioned issue #598) do not relate to NRE bug fixed by this request at all.

Changes Proposed in this pull request:
- Do not iterate on collection returned by [TakeMediasAsync](https://github.com/jamesmontemagno/MediaPlugin/blob/a6de2cb0cd5d94d1e155daa6696c1ed5e96d17c0/src/Media.Plugin/Android/MediaImplementation.cs#L570) if it is null.
- Return null if operation was canceled or dismissed.