### PR TITLE
[iOSResizeMultiplePhotosCrash] I have fixed the crash of iOS when sel…

### DIFF
--- a/src/Media.Plugin/iOS/ECLImagePickerViewController.cs
+++ b/src/Media.Plugin/iOS/ECLImagePickerViewController.cs
@@ -164,89 +164,11 @@ namespace Plugin.Media
 			rep?.Dispose();
 			rep = null;
 
-			var percent = 1.0f;
-			if (_options.PhotoSize != PhotoSize.Full)
-			{
-				try
-				{
-					switch (_options.PhotoSize)
-					{
-						case PhotoSize.Large:
-							percent = .75f;
-							break;
-						case PhotoSize.Medium:
-							percent = .5f;
-							break;
-						case PhotoSize.Small:
-							percent = .25f;
-							break;
-						case PhotoSize.Custom:
-							percent = (float)_options.CustomPhotoSize / 100f;
-							break;
-					}
-
-					if (_options.PhotoSize == PhotoSize.MaxWidthHeight && _options.MaxWidthHeight.HasValue)
-					{
-						var max = Math.Max(image.CGImage.Width, image.CGImage.Height);
-						if (max > _options.MaxWidthHeight.Value)
-						{
-							percent = (float)_options.MaxWidthHeight.Value / (float)max;
-						}
-					}
-
-					if (percent < 1.0f)
-					{
-						//begin resizing image
-						image = image.ResizeImageWithAspectRatio(percent);
-					}
-
-				}
-				catch (Exception ex)
-				{
-					Console.WriteLine($"Unable to compress image: {ex}");
-				}
-			}
-
-
-			NSDictionary meta = null;
-			try
-			{
-				//meta = PhotoLibraryAccess.GetPhotoLibraryMetadata(asset.AssetUrl);
-
-				//meta = info[UIImagePickerController.MediaMetadata] as NSDictionary;
-				if (meta != null && meta.ContainsKey(ImageIO.CGImageProperties.Orientation))
-				{
-					var newMeta = new NSMutableDictionary();
-					newMeta.SetValuesForKeysWithDictionary(meta);
-					var newTiffDict = new NSMutableDictionary();
-					newTiffDict.SetValuesForKeysWithDictionary(meta[ImageIO.CGImageProperties.TIFFDictionary] as NSDictionary);
-					newTiffDict.SetValueForKey(meta[ImageIO.CGImageProperties.Orientation], ImageIO.CGImageProperties.TIFFOrientation);
-					newMeta[ImageIO.CGImageProperties.TIFFDictionary] = newTiffDict;
-
-					meta = newMeta;
-				}
-				var location = _options.Location;
-				if (meta != null && location != null)
-				{
-					meta = MediaPickerDelegate.SetGpsLocation(meta, location);
-				}
-			}
-			catch (Exception ex)
-			{
-				Console.WriteLine($"Unable to get metadata: {ex}");
-			}
-
-			//iOS quality is 0.0-1.0
-			var quality = (_options.CompressionQuality / 100f);
-			var savedImage = false;
-			if (meta != null)
-				savedImage = MediaPickerDelegate.SaveImageWithMetadata(image, quality, meta, path);
-
-			if (!savedImage)
-				image.AsJPEG(quality).Save(path, true);
+			image.AsJPEG().Save(path, true);
 
 			image?.Dispose();
 			image = null;
+			GC.Collect(GC.MaxGeneration, GCCollectionMode.Default);
 
 			string aPath = null;
 			//try to get the album path's url

--- a/src/Media.Plugin/iOS/MediaImplementation.cs
+++ b/src/Media.Plugin/iOS/MediaImplementation.cs
@@ -24,10 +24,9 @@ namespace Plugin.Media
         /// </summary>
         public static UIStatusBarStyle StatusBarStyle { get; set; }
 
-       
 
-        ///<inheritdoc/>
-        public Task<bool> Initialize() => Task.FromResult(true);
+		///<inheritdoc/>
+		public Task<bool> Initialize() => Task.FromResult(true);
 
         /// <summary>
         /// Implementation
@@ -379,8 +378,102 @@ namespace Plugin.Media
 					return Task.FromResult(new List<MediaFile>());
 				}
 
+				var files = t.Result;
+				Parallel.ForEach(files, mediaFile =>
+				{
+					ResizeAndCompressImage(options, mediaFile);
+				});
+
 				return t;
 			}).Unwrap();
+		}
+
+		private static void ResizeAndCompressImage(StoreCameraMediaOptions options, MediaFile mediaFile)
+		{
+			var image = UIImage.FromFile(mediaFile.Path);
+			var percent = 1.0f;
+			if (options.PhotoSize != PhotoSize.Full)
+			{
+				try
+				{
+					switch (options.PhotoSize)
+					{
+						case PhotoSize.Large:
+							percent = .75f;
+							break;
+						case PhotoSize.Medium:
+							percent = .5f;
+							break;
+						case PhotoSize.Small:
+							percent = .25f;
+							break;
+						case PhotoSize.Custom:
+							percent = (float)options.CustomPhotoSize / 100f;
+							break;
+					}
+
+					if (options.PhotoSize == PhotoSize.MaxWidthHeight && options.MaxWidthHeight.HasValue)
+					{
+						var max = Math.Max(image.Size.Width, image.Size.Height);
+						if (max > options.MaxWidthHeight.Value)
+						{
+							percent = (float)options.MaxWidthHeight.Value / (float)max;
+						}
+					}
+
+					if (percent < 1.0f)
+					{
+						//begin resizing image
+						image = image.ResizeImageWithAspectRatio(percent);
+					}
+
+					NSDictionary meta = null;
+					try
+					{
+						//meta = PhotoLibraryAccess.GetPhotoLibraryMetadata(asset.AssetUrl);
+
+						//meta = info[UIImagePickerController.MediaMetadata] as NSDictionary;
+						if (meta != null && meta.ContainsKey(ImageIO.CGImageProperties.Orientation))
+						{
+							var newMeta = new NSMutableDictionary();
+							newMeta.SetValuesForKeysWithDictionary(meta);
+							var newTiffDict = new NSMutableDictionary();
+							newTiffDict.SetValuesForKeysWithDictionary(meta[ImageIO.CGImageProperties.TIFFDictionary] as NSDictionary);
+							newTiffDict.SetValueForKey(meta[ImageIO.CGImageProperties.Orientation], ImageIO.CGImageProperties.TIFFOrientation);
+							newMeta[ImageIO.CGImageProperties.TIFFDictionary] = newTiffDict;
+
+							meta = newMeta;
+						}
+						var location = options.Location;
+						if (meta != null && location != null)
+						{
+							meta = MediaPickerDelegate.SetGpsLocation(meta, location);
+						}
+					}
+					catch (Exception ex)
+					{
+						Console.WriteLine($"Unable to get metadata: {ex}");
+					}
+
+					//iOS quality is 0.0-1.0
+					var quality = (options.CompressionQuality / 100f);
+					var savedImage = false;
+					if (meta != null)
+						savedImage = MediaPickerDelegate.SaveImageWithMetadata(image, quality, meta, mediaFile.Path);
+
+					if (!savedImage)
+						image.AsJPEG(quality).Save(mediaFile.Path, true);
+
+					image?.Dispose();
+					image = null;
+
+					GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
+				}
+				catch (Exception ex)
+				{
+					Console.WriteLine($"Unable to compress image: {ex}");
+				}
+			}
 		}
 
 		private void Dismiss(UIPopoverController popover, UIViewController picker)
@@ -399,7 +492,7 @@ namespace Plugin.Media
 			{
 
 			}
-
+			GC.Collect(GC.MaxGeneration, GCCollectionMode.Default);
 			Interlocked.Exchange(ref pickerDelegate, null);
 		}
 		


### PR DESCRIPTION
Hi James,

I have made a very nice improvement in the Plugin.Media. 
Please check it and give me hints and feedback for more improvement. 
I hope you would like it. 
If you are happy, can we please release it in NuGet beta at your convenience?

Please take a moment to fill out the following:

Fixes # .

Changes Proposed in this pull request:

- We have fixed an issue where Plugin.Media was crashing when selecting multiple images (More than 15) with resizing and compressing functionality on. With this fix, a user will be able to select more than 100 photos with resizing and compressing functionality on. 
- In order to fix this above-mentioned issue, I have to separate selecting and resizing function. This was required to improve performance. 
- I have also turned on parallel processing for resizing and compressing of photos. This has made it a lot faster.
- These changes have made it performing really well on iOS devices.


Sample Code for testing.
				var picked = await CrossMedia.Current.PickPhotosAsync(new PickMediaOptions
				{
					PhotoSize = PhotoSize.MaxWidthHeight,
					MaxWidthHeight = 1024
				},
				new MultiPickerOptions
				{
					MaximumImagesCount = 100
				});

Regards and Thanks,
Manbir Rakhra
Company: Skedulo Pty Ltd.
Mobile No: +61 413 230 257