### PR TITLE
Bugfix 730: TIFFDict Meta Data Exception On iOS MediaPickerDelegate.cs

### DIFF
--- a/src/Media.Plugin/iOS/MediaPickerDelegate.cs
+++ b/src/Media.Plugin/iOS/MediaPickerDelegate.cs
@@ -514,9 +514,11 @@ namespace Plugin.Media
 
 				if (meta.ContainsKey(ImageIO.CGImageProperties.TIFFDictionary))
 				{
-					var newTiffDict = meta[ImageIO.CGImageProperties.TIFFDictionary] as NSDictionary;
-					if (newTiffDict != null)
+					var existingTiffDict = meta[ImageIO.CGImageProperties.TIFFDictionary] as NSDictionary;
+					if (existingTiffDict != null)
 					{
+						var newTiffDict = new NSMutableDictionary();
+						newTiffDict.SetValuesForKeysWithDictionary(existingTiffDict);
 						newTiffDict.SetValueForKey(meta[ImageIO.CGImageProperties.Orientation], ImageIO.CGImageProperties.TIFFOrientation);
 						destinationOptions.TiffDictionary = new CGImagePropertiesTiff(newTiffDict);
 					}


### PR DESCRIPTION
This pull request fixes the issue #730, the problem was that you are trying to set the keys for a non-mutable dictionary, this is not allowed on IOS. Because of this exception, all the code bellow TIFFDictionary was not executed and GPS metadata was not set.

Changes Proposed in this pull request:
- Instead of directly set the value of ImageIO.CGImageProperties.Orientation in NSDictionary I define a mutable dictionary, import all the values from the TIFFDictionary and then set the value of ImageIO.CGImageProperties.Orientation

