### PR TITLE
BugFix 747: Missing image metadata(EXIF, TIFF, GPS ) when trying to pick multiple photos on IOS

### DIFF
--- a/src/Media.Plugin/iOS/MediaPickerDelegate.cs
+++ b/src/Media.Plugin/iOS/MediaPickerDelegate.cs
@@ -315,12 +315,10 @@ namespace Plugin.Media
 
         private async Task<MediaFile> GetPictureMediaFileInternal(UIImage image, NSDictionary meta, NSUrl url, string outputDir)
 		{
-			var image = (UIImage)info[UIImagePickerController.EditedImage] ?? (UIImage)info[UIImagePickerController.OriginalImage];
-
 			if (image == null)
                 return null;
 
-			photoType = ((info[UIImagePickerController.ReferenceUrl] as NSUrl).PathExtension == "PNG") ? "png" : "jpg";
+			photoType = ((meta[UIImagePickerController.ReferenceUrl] as NSUrl).PathExtension == "PNG") ? "png" : "jpg";
 
 			var path = GetOutputPath(MediaImplementation.TypeImage,
 				options.Directory ?? ((IsCaptured) ? string.Empty : "temp"),


### PR DESCRIPTION
**In ECLImagePickerViewController** 
I remove existing logic for converting a ALAsset to MediaFile and reuse existing logic from MediaPickerDelegate.GetPictureMediaFile

**In MediaPickerDelegate** 
- I changed the existing method GetPictureMediaFile to GetPictureMediaFileInternal and define 3 parameters GetPictureMediaFileInternal(UIImage image, NSDictionary meta, NSUrl url). I was needed this so I can reuse the existing logic
- I define two overrides for the GetPictureMediaFile, one to accept ALAsset and the other one to accept NSDictionary

