### PR TITLE
Adding fix for cancelling when clicking background overlay on ios tablet

### DIFF
--- a/src/Media.Plugin/iOS/ECLImagePickerViewController.cs
+++ b/src/Media.Plugin/iOS/ECLImagePickerViewController.cs
@@ -130,6 +130,12 @@ namespace Plugin.Media
 			return pluralTitle;
 		}
 
+		public override void ViewWillDisappear(bool animated)
+		{
+			base.ViewWillDisappear(animated);
+			CancelledPicker();
+		}
+
 		public static ELCImagePickerViewController Create(StoreCameraMediaOptions options = null, MultiPickerOptions pickerOptions = null)
 		{
 			pickerOptions = pickerOptions ?? new MultiPickerOptions();


### PR DESCRIPTION
Please take a moment to fill out the following:

On iOS tablet our app was crashing if we:
1) Call PickPhotosAsync
2) Dismiss the modal by clicking the background
3) Call PickPhotosAsync again
4) Crash

Changes Proposed in this pull request:
Adding an extra layer of cancellation when we click the background of the view to ensure it fully cancels the picker.
