### PR TITLE
bugfix #640 clicking multiple times on a picture in iOS causing back …

### DIFF
--- a/src/Media.Plugin/iOS/MediaPickerDelegate.cs
+++ b/src/Media.Plugin/iOS/MediaPickerDelegate.cs
@@ -47,8 +47,12 @@ namespace Plugin.Media
 		
 		public Task<List<MediaFile>> Task => tcs.Task;
 
+		private bool isFinished;
 		public override async void FinishedPickingMedia(UIImagePickerController picker, NSDictionary info)
 		{
+			if (isFinished)
+				return;
+			isFinished = true;
 			RemoveOrientationChangeObserverAndNotifications();
 
 			MediaFile mediaFile;
@@ -77,6 +81,7 @@ namespace Plugin.Media
                     tcs.SetException(new FileNotFoundException());
 				else
 					tcs.TrySetResult(new List<MediaFile> { mediaFile });
+				isFinished = false;
 			});
 		}
 


### PR DESCRIPTION
…too many times, bug caused by loop on event FinishedPickingMedia in every click, and calling dismiss event in consequence

Please take a moment to fill out the following:

Fixes # .

Changes Proposed in this pull request:
-
-
- 
