### PR TITLE
Made sure PNG is only used when image actually IS a PNG.

### DIFF
--- a/src/Media.Plugin/iOS/MediaImplementation.cs
+++ b/src/Media.Plugin/iOS/MediaImplementation.cs
@@ -14,64 +14,64 @@ using System.Collections.Generic;
 
 namespace Plugin.Media
 {
-    /// <summary>
-    /// Implementation for Media
-    /// </summary>
-    public class MediaImplementation : IMedia
-    {
-        /// <summary>
-        /// Color of the status bar
-        /// </summary>
-        public static UIStatusBarStyle StatusBarStyle { get; set; }
+	/// <summary>
+	/// Implementation for Media
+	/// </summary>
+	public class MediaImplementation : IMedia
+	{
+		/// <summary>
+		/// Color of the status bar
+		/// </summary>
+		public static UIStatusBarStyle StatusBarStyle { get; set; }
 
 
 		///<inheritdoc/>
 		public Task<bool> Initialize() => Task.FromResult(true);
 
-        /// <summary>
-        /// Implementation
-        /// </summary>
-        public MediaImplementation()
-        {
-            StatusBarStyle = UIApplication.SharedApplication.StatusBarStyle;
-            IsCameraAvailable = UIImagePickerController.IsCameraDeviceAvailable(UIKit.UIImagePickerControllerCameraDevice.Front)
+		/// <summary>
+		/// Implementation
+		/// </summary>
+		public MediaImplementation()
+		{
+			StatusBarStyle = UIApplication.SharedApplication.StatusBarStyle;
+			IsCameraAvailable = UIImagePickerController.IsCameraDeviceAvailable(UIKit.UIImagePickerControllerCameraDevice.Front)
 									   | UIImagePickerController.IsCameraDeviceAvailable(UIKit.UIImagePickerControllerCameraDevice.Rear);
 
-            var availableCameraMedia = UIImagePickerController.AvailableMediaTypes(UIImagePickerControllerSourceType.Camera) ?? new string[0];
-            var avaialbleLibraryMedia = UIImagePickerController.AvailableMediaTypes(UIImagePickerControllerSourceType.PhotoLibrary) ?? new string[0];
+			var availableCameraMedia = UIImagePickerController.AvailableMediaTypes(UIImagePickerControllerSourceType.Camera) ?? new string[0];
+			var avaialbleLibraryMedia = UIImagePickerController.AvailableMediaTypes(UIImagePickerControllerSourceType.PhotoLibrary) ?? new string[0];
 
-            foreach (var type in availableCameraMedia.Concat(avaialbleLibraryMedia))
-            {
-                if (type == TypeMovie)
-                    IsTakeVideoSupported = IsPickVideoSupported = true;
-                else if (type == TypeImage)
-                    IsTakePhotoSupported = IsPickPhotoSupported = true;
-            }
-        }
-        /// <inheritdoc/>
-        public bool IsCameraAvailable { get; }
+			foreach (var type in availableCameraMedia.Concat(avaialbleLibraryMedia))
+			{
+				if (type == TypeMovie)
+					IsTakeVideoSupported = IsPickVideoSupported = true;
+				else if (type == TypeImage)
+					IsTakePhotoSupported = IsPickPhotoSupported = true;
+			}
+		}
+		/// <inheritdoc/>
+		public bool IsCameraAvailable { get; }
 
-        /// <inheritdoc/>
-        public bool IsTakePhotoSupported { get; }
+		/// <inheritdoc/>
+		public bool IsTakePhotoSupported { get; }
 
-        /// <inheritdoc/>
-        public bool IsPickPhotoSupported { get; }
+		/// <inheritdoc/>
+		public bool IsPickPhotoSupported { get; }
 
-        /// <inheritdoc/>
-        public bool IsTakeVideoSupported { get; }
+		/// <inheritdoc/>
+		public bool IsTakeVideoSupported { get; }
 
-        /// <inheritdoc/>
-        public bool IsPickVideoSupported { get; }
+		/// <inheritdoc/>
+		public bool IsPickVideoSupported { get; }
 
-        
-        /// <summary>
-        /// Picks a photo from the default gallery
-        /// </summary>
-        /// <returns>Media file or null if canceled</returns>
-        public async Task<MediaFile> PickPhotoAsync(PickMediaOptions options = null, CancellationToken token = default(CancellationToken))
-        {
-            if (!IsPickPhotoSupported)
-                throw new NotSupportedException();
+
+		/// <summary>
+		/// Picks a photo from the default gallery
+		/// </summary>
+		/// <returns>Media file or null if canceled</returns>
+		public async Task<MediaFile> PickPhotoAsync(PickMediaOptions options = null, CancellationToken token = default(CancellationToken))
+		{
+			if (!IsPickPhotoSupported)
+				throw new NotSupportedException();
 
 
 			//Does not need permission on iOS 11
@@ -93,10 +93,10 @@ namespace Plugin.Media
 				SaveMetaData = options?.SaveMetaData ?? true,
 				SaveToAlbum = false,
 				ModalPresentationStyle = options?.ModalPresentationStyle ?? MediaPickerModalPresentationStyle.FullScreen,
-            };
+			};
 
-            return await GetMediaAsync(UIImagePickerControllerSourceType.PhotoLibrary, TypeImage, cameraOptions, token);
-        }
+			return await GetMediaAsync(UIImagePickerControllerSourceType.PhotoLibrary, TypeImage, cameraOptions, token);
+		}
 
 		public async Task<List<MediaFile>> PickPhotosAsync(PickMediaOptions options = null, MultiPickerOptions pickerOptions = null, CancellationToken token = default(CancellationToken))
 		{
@@ -127,23 +127,23 @@ namespace Plugin.Media
 			return await GetMediasAsync(UIImagePickerControllerSourceType.PhotoLibrary, TypeImage, cameraOptions, pickerOptions, token);
 		}
 
-        /// <summary>
-        /// Take a photo async with specified options
-        /// </summary>
-        /// <param name="options">Camera Media Options</param>
-        /// <returns>Media file of photo or null if canceled</returns>
-        public async Task<MediaFile> TakePhotoAsync(StoreCameraMediaOptions options, CancellationToken token = default(CancellationToken))
-        {
-            if (!IsTakePhotoSupported)
-                throw new NotSupportedException();
-            if (!IsCameraAvailable)
-                throw new NotSupportedException();
+		/// <summary>
+		/// Take a photo async with specified options
+		/// </summary>
+		/// <param name="options">Camera Media Options</param>
+		/// <returns>Media file of photo or null if canceled</returns>
+		public async Task<MediaFile> TakePhotoAsync(StoreCameraMediaOptions options, CancellationToken token = default(CancellationToken))
+		{
+			if (!IsTakePhotoSupported)
+				throw new NotSupportedException();
+			if (!IsCameraAvailable)
+				throw new NotSupportedException();
 
-            CheckUsageDescription(cameraDescription);
+			CheckUsageDescription(cameraDescription);
 			if (options.SaveToAlbum)
 				CheckUsageDescription(photoAddDescription);
 
-            VerifyCameraOptions(options);
+			VerifyCameraOptions(options);
 
 			var permissionsToCheck = new List<Permission> { Permission.Camera };
 			if (options.SaveToAlbum)
@@ -151,22 +151,22 @@ namespace Plugin.Media
 
 			await CheckPermissions(permissionsToCheck.ToArray());
 
-            return await GetMediaAsync(UIImagePickerControllerSourceType.Camera, TypeImage, options, token);
-        }
+			return await GetMediaAsync(UIImagePickerControllerSourceType.Camera, TypeImage, options, token);
+		}
 
 
-        /// <summary>
-        /// Picks a video from the default gallery
-        /// </summary>
-        /// <returns>Media file of video or null if canceled</returns>
-        public async Task<MediaFile> PickVideoAsync(CancellationToken token = default(CancellationToken))
-        {
-            if (!IsPickVideoSupported)
-                throw new NotSupportedException();
+		/// <summary>
+		/// Picks a video from the default gallery
+		/// </summary>
+		/// <returns>Media file of video or null if canceled</returns>
+		public async Task<MediaFile> PickVideoAsync(CancellationToken token = default(CancellationToken))
+		{
+			if (!IsPickVideoSupported)
+				throw new NotSupportedException();
 
-            var backgroundTask = UIApplication.SharedApplication.BeginBackgroundTask(() => { });
+			var backgroundTask = UIApplication.SharedApplication.BeginBackgroundTask(() => { });
 
-            
+
 			//Not needed on iOS 11 since it runs in different process
 			if (!UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
 			{
@@ -176,25 +176,25 @@ namespace Plugin.Media
 
 			var media = await GetMediaAsync(UIImagePickerControllerSourceType.PhotoLibrary, TypeMovie, token: token);
 
-            UIApplication.SharedApplication.EndBackgroundTask(backgroundTask);
+			UIApplication.SharedApplication.EndBackgroundTask(backgroundTask);
 
-            return media;
-        }
-        
+			return media;
+		}
 
-        /// <summary>
-        /// Take a video with specified options
-        /// </summary>
-        /// <param name="options">Video Media Options</param>
-        /// <returns>Media file of new video or null if canceled</returns>
-        public async Task<MediaFile> TakeVideoAsync(StoreVideoOptions options, CancellationToken token = default(CancellationToken))
-        {
-            if (!IsTakeVideoSupported)
-                throw new NotSupportedException();
-            if (!IsCameraAvailable)
-                throw new NotSupportedException();
 
-            CheckUsageDescription(cameraDescription, microphoneDescription);
+		/// <summary>
+		/// Take a video with specified options
+		/// </summary>
+		/// <param name="options">Video Media Options</param>
+		/// <returns>Media file of new video or null if canceled</returns>
+		public async Task<MediaFile> TakeVideoAsync(StoreVideoOptions options, CancellationToken token = default(CancellationToken))
+		{
+			if (!IsTakeVideoSupported)
+				throw new NotSupportedException();
+			if (!IsCameraAvailable)
+				throw new NotSupportedException();
+
+			CheckUsageDescription(cameraDescription, microphoneDescription);
 
 			if (options.SaveToAlbum)
 				CheckUsageDescription(photoAddDescription);
@@ -207,91 +207,91 @@ namespace Plugin.Media
 
 			await CheckPermissions(permissionsToCheck.ToArray());
 
-            return await GetMediaAsync(UIImagePickerControllerSourceType.Camera, TypeMovie, options, token);
-        }
+			return await GetMediaAsync(UIImagePickerControllerSourceType.Camera, TypeMovie, options, token);
+		}
 
-        private UIPopoverController popover;
+		private UIPopoverController popover;
 		private UIImagePickerControllerDelegate pickerDelegate;
-        /// <summary>
-        /// image type
-        /// </summary>
-        public const string TypeImage = "public.image";
-        /// <summary>
-        /// movie type
-        /// </summary>
-        public const string TypeMovie = "public.movie";
+		/// <summary>
+		/// image type
+		/// </summary>
+		public const string TypeImage = "public.image";
+		/// <summary>
+		/// movie type
+		/// </summary>
+		public const string TypeMovie = "public.movie";
 
-        private void VerifyOptions(StoreMediaOptions options)
-        {
-            if (options == null)
-                throw new ArgumentNullException("options");
-            if (options.Directory != null && Path.IsPathRooted(options.Directory))
-                throw new ArgumentException("options.Directory must be a relative path", "options");
-        }
+		private void VerifyOptions(StoreMediaOptions options)
+		{
+			if (options == null)
+				throw new ArgumentNullException("options");
+			if (options.Directory != null && Path.IsPathRooted(options.Directory))
+				throw new ArgumentException("options.Directory must be a relative path", "options");
+		}
 
-        private void VerifyCameraOptions(StoreCameraMediaOptions options)
-        {
-            VerifyOptions(options);
-            if (!Enum.IsDefined(typeof(CameraDevice), options.DefaultCamera))
-                throw new ArgumentException("options.Camera is not a member of CameraDevice");
-        }
+		private void VerifyCameraOptions(StoreCameraMediaOptions options)
+		{
+			VerifyOptions(options);
+			if (!Enum.IsDefined(typeof(CameraDevice), options.DefaultCamera))
+				throw new ArgumentException("options.Camera is not a member of CameraDevice");
+		}
 
-        private static MediaPickerController SetupController(MediaPickerDelegate mpDelegate, UIImagePickerControllerSourceType sourceType, string mediaType, StoreCameraMediaOptions options = null)
-        {
-            var picker = new MediaPickerController(mpDelegate);
-            picker.MediaTypes = new[] { mediaType };
-            picker.SourceType = sourceType;
+		private static MediaPickerController SetupController(MediaPickerDelegate mpDelegate, UIImagePickerControllerSourceType sourceType, string mediaType, StoreCameraMediaOptions options = null)
+		{
+			var picker = new MediaPickerController(mpDelegate);
+			picker.MediaTypes = new[] { mediaType };
+			picker.SourceType = sourceType;
 
-            if (sourceType == UIImagePickerControllerSourceType.Camera)
-            {
-                picker.CameraDevice = GetUICameraDevice(options.DefaultCamera);
-                picker.AllowsEditing = options?.AllowCropping ?? false;
+			if (sourceType == UIImagePickerControllerSourceType.Camera)
+			{
+				picker.CameraDevice = GetUICameraDevice(options.DefaultCamera);
+				picker.AllowsEditing = options?.AllowCropping ?? false;
 
-                if (options.OverlayViewProvider != null)
-                {
-                    var overlay = options.OverlayViewProvider();
-                    if (overlay is UIView)
-                    {
-                        picker.CameraOverlayView = overlay as UIView;
-                    }
-                }
-                if (mediaType == TypeImage)
-                {
-                    picker.CameraCaptureMode = UIImagePickerControllerCameraCaptureMode.Photo;
-                }
-                else if (mediaType == TypeMovie)
-                {
-                    var voptions = (StoreVideoOptions)options;
+				if (options.OverlayViewProvider != null)
+				{
+					var overlay = options.OverlayViewProvider();
+					if (overlay is UIView)
+					{
+						picker.CameraOverlayView = overlay as UIView;
+					}
+				}
+				if (mediaType == TypeImage)
+				{
+					picker.CameraCaptureMode = UIImagePickerControllerCameraCaptureMode.Photo;
+				}
+				else if (mediaType == TypeMovie)
+				{
+					var voptions = (StoreVideoOptions)options;
 
-                    picker.CameraCaptureMode = UIImagePickerControllerCameraCaptureMode.Video;
-                    picker.VideoQuality = GetQuailty(voptions.Quality);
-                    picker.VideoMaximumDuration = voptions.DesiredLength.TotalSeconds;
-                }
-            }
+					picker.CameraCaptureMode = UIImagePickerControllerCameraCaptureMode.Video;
+					picker.VideoQuality = GetQuailty(voptions.Quality);
+					picker.VideoMaximumDuration = voptions.DesiredLength.TotalSeconds;
+				}
+			}
 
-            return picker;
-        }
+			return picker;
+		}
 
-        private Task<MediaFile> GetMediaAsync(UIImagePickerControllerSourceType sourceType, string mediaType, StoreCameraMediaOptions options = null, CancellationToken token = default(CancellationToken))
-        {
-			
+		private Task<MediaFile> GetMediaAsync(UIImagePickerControllerSourceType sourceType, string mediaType, StoreCameraMediaOptions options = null, CancellationToken token = default(CancellationToken))
+		{
+
 			var viewController = GetHostViewController();
 
-	        if (token.IsCancellationRequested)
-				return Task.FromResult((MediaFile) null);
+			if (token.IsCancellationRequested)
+				return Task.FromResult((MediaFile)null);
 
-            var ndelegate = new MediaPickerDelegate(viewController, sourceType, options, token);
-            var od = Interlocked.CompareExchange(ref pickerDelegate, ndelegate, null);
-            if (od != null)
-                throw new InvalidOperationException("Only one operation can be active at a time");
+			var ndelegate = new MediaPickerDelegate(viewController, sourceType, options, token);
+			var od = Interlocked.CompareExchange(ref pickerDelegate, ndelegate, null);
+			if (od != null)
+				throw new InvalidOperationException("Only one operation can be active at a time");
 
-            var picker = SetupController(ndelegate, sourceType, mediaType, options);
+			var picker = SetupController(ndelegate, sourceType, mediaType, options);
 
-            if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad && sourceType == UIImagePickerControllerSourceType.PhotoLibrary)
-            {
-                ndelegate.Popover = popover = new UIPopoverController(picker);
-                ndelegate.Popover.Delegate = new MediaPickerPopoverDelegate(ndelegate, picker);
-                ndelegate.DisplayPopover();
+			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad && sourceType == UIImagePickerControllerSourceType.PhotoLibrary)
+			{
+				ndelegate.Popover = popover = new UIPopoverController(picker);
+				ndelegate.Popover.Delegate = new MediaPickerPopoverDelegate(ndelegate, picker);
+				ndelegate.DisplayPopover();
 
 				token.Register(() =>
 				{
@@ -303,16 +303,16 @@ namespace Plugin.Media
 						ndelegate.CancelTask();
 					});
 				});
-            }
-            else
-            {
-                if (UIDevice.CurrentDevice.CheckSystemVersion(9, 0))
-                {
-	                picker.ModalPresentationStyle = options?.ModalPresentationStyle == MediaPickerModalPresentationStyle.OverFullScreen
-		                ? UIModalPresentationStyle.OverFullScreen
-		                : UIModalPresentationStyle.FullScreen;
-                }
-                viewController.PresentViewController(picker, true, null);
+			}
+			else
+			{
+				if (UIDevice.CurrentDevice.CheckSystemVersion(9, 0))
+				{
+					picker.ModalPresentationStyle = options?.ModalPresentationStyle == MediaPickerModalPresentationStyle.OverFullScreen
+						? UIModalPresentationStyle.OverFullScreen
+						: UIModalPresentationStyle.FullScreen;
+				}
+				viewController.PresentViewController(picker, true, null);
 
 				token.Register(() =>
 				{
@@ -320,20 +320,20 @@ namespace Plugin.Media
 						return;
 
 					NSRunLoop.Main.BeginInvokeOnMainThread(() =>
-					{						
+					{
 						picker.DismissModalViewController(true);
 						ndelegate.CancelTask();
 					});
 				});
 			}
 
-            return ndelegate.Task.ContinueWith(t =>
-            {
+			return ndelegate.Task.ContinueWith(t =>
+			{
 				Dismiss(popover, picker);
 
 				return t.Result == null ? null : t.Result.FirstOrDefault();
 			});
-        }
+		}
 
 		private Task<List<MediaFile>> GetMediasAsync(UIImagePickerControllerSourceType sourceType, string mediaType, StoreCameraMediaOptions options = null, MultiPickerOptions pickerOptions = null, CancellationToken token = default(CancellationToken))
 		{
@@ -346,7 +346,7 @@ namespace Plugin.Media
 			var od = Interlocked.CompareExchange(ref pickerDelegate, ndelegate, null);
 			if (od != null)
 				throw new InvalidOperationException("Only one operation can be active at a time");
-			
+
 			var picker = ELCImagePickerViewController.Create(options, pickerOptions);
 
 			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad && sourceType == UIImagePickerControllerSourceType.PhotoLibrary)
@@ -363,7 +363,7 @@ namespace Plugin.Media
 				}
 				viewController.PresentViewController(picker, true, null);
 			}
-			
+
 			// TODO: Make this use the existing Delegate?
 			return picker.Completion.ContinueWith(t =>
 			{
@@ -372,7 +372,7 @@ namespace Plugin.Media
 				{
 					picker.DismissViewController(true, null);
 				});
-				
+
 				if (t.IsCanceled || t.Exception != null)
 				{
 					return Task.FromResult(new List<MediaFile>());
@@ -381,7 +381,7 @@ namespace Plugin.Media
 				var files = t.Result;
 				Parallel.ForEach(files, mediaFile =>
 				{
-					ResizeAndCompressImage(options, mediaFile, Path.GetExtension(mediaFile.Path));
+					ResizeAndCompressImage(options, mediaFile, Path.GetExtension(mediaFile.Path).Replace(".", string.Empty));
 				});
 
 				return t;
@@ -426,54 +426,41 @@ namespace Plugin.Media
 						//begin resizing image
 						image = image.ResizeImageWithAspectRatio(percent);
 					}
-
-					NSDictionary meta = null;
-					try
-					{
-						//meta = PhotoLibraryAccess.GetPhotoLibraryMetadata(asset.AssetUrl);
-
-						//meta = info[UIImagePickerController.MediaMetadata] as NSDictionary;
-						if (meta != null && meta.ContainsKey(ImageIO.CGImageProperties.Orientation))
-						{
-							var newMeta = new NSMutableDictionary();
-							newMeta.SetValuesForKeysWithDictionary(meta);
-							var newTiffDict = new NSMutableDictionary();
-							newTiffDict.SetValuesForKeysWithDictionary(meta[ImageIO.CGImageProperties.TIFFDictionary] as NSDictionary);
-							newTiffDict.SetValueForKey(meta[ImageIO.CGImageProperties.Orientation], ImageIO.CGImageProperties.TIFFOrientation);
-							newMeta[ImageIO.CGImageProperties.TIFFDictionary] = newTiffDict;
-
-							meta = newMeta;
-						}
-						var location = options.Location;
-						if (meta != null && location != null)
-						{
-							meta = MediaPickerDelegate.SetGpsLocation(meta, location);
-						}
-					}
-					catch (Exception ex)
-					{
-						Console.WriteLine($"Unable to get metadata: {ex}");
-					}
-
-					//iOS quality is 0.0-1.0
-					var quality = (options.CompressionQuality / 100f);
-					var savedImage = false;
-					if (meta != null)
-						savedImage = MediaPickerDelegate.SaveImageWithMetadata(image, quality, meta, mediaFile.Path, pathExtension);
-
-					if (!savedImage)
-						image.AsJPEG(quality).Save(mediaFile.Path, true);
-
-					image?.Dispose();
-					image = null;
-
-					GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
 				}
 				catch (Exception ex)
 				{
 					Console.WriteLine($"Unable to compress image: {ex}");
 				}
 			}
+			NSDictionary meta = null;
+			if (options.SaveMetaData)
+			{
+				try
+				{
+					meta = PhotoLibraryAccess.GetPhotoLibraryMetadata(new NSUrl(mediaFile.AlbumPath));
+				}
+				catch (Exception ex)
+				{
+					Console.WriteLine($"Unable to get metadata: {ex}");
+				}
+			}
+			//iOS quality is 0.0-1.0
+			var quality = (options.CompressionQuality / 100f);
+			var savedImage = false;
+			if (meta != null)
+				savedImage = MediaPickerDelegate.SaveImageWithMetadata(image, quality, meta, mediaFile.Path, pathExtension);
+
+			if (!savedImage)
+			{
+				if (pathExtension == "png")
+					image.AsPNG().Save(mediaFile.Path, true);
+				else
+					image.AsJPEG(quality).Save(mediaFile.Path, true);
+			}
+
+			image?.Dispose();
+			image = null;
+			GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
 		}
 
 		private void Dismiss(UIPopoverController popover, UIViewController picker)
@@ -495,7 +482,7 @@ namespace Plugin.Media
 			GC.Collect(GC.MaxGeneration, GCCollectionMode.Default);
 			Interlocked.Exchange(ref pickerDelegate, null);
 		}
-		
+
 		private static UIViewController GetHostViewController()
 		{
 			UIViewController viewController = null;
@@ -522,39 +509,39 @@ namespace Plugin.Media
 		}
 
 		private static UIImagePickerControllerCameraDevice GetUICameraDevice(CameraDevice device)
-        {
-            switch (device)
-            {
-                case CameraDevice.Front:
-                    return UIImagePickerControllerCameraDevice.Front;
-                case CameraDevice.Rear:
-                    return UIImagePickerControllerCameraDevice.Rear;
-                default:
-                    throw new NotSupportedException();
-            }
-        }
+		{
+			switch (device)
+			{
+				case CameraDevice.Front:
+					return UIImagePickerControllerCameraDevice.Front;
+				case CameraDevice.Rear:
+					return UIImagePickerControllerCameraDevice.Rear;
+				default:
+					throw new NotSupportedException();
+			}
+		}
 
-        private static UIImagePickerControllerQualityType GetQuailty(VideoQuality quality)
-        {
-            switch (quality)
-            {
-                case VideoQuality.Low:
-                    return UIImagePickerControllerQualityType.Low;
-                case VideoQuality.Medium:
-                    return UIImagePickerControllerQualityType.Medium;
-                default:
-                    return UIImagePickerControllerQualityType.High;
-            }
-        }
+		private static UIImagePickerControllerQualityType GetQuailty(VideoQuality quality)
+		{
+			switch (quality)
+			{
+				case VideoQuality.Low:
+					return UIImagePickerControllerQualityType.Low;
+				case VideoQuality.Medium:
+					return UIImagePickerControllerQualityType.Medium;
+				default:
+					return UIImagePickerControllerQualityType.High;
+			}
+		}
 
-        static async Task CheckPermissions(params Permission[] permissions)
-        {
+		static async Task CheckPermissions(params Permission[] permissions)
+		{
 			//See which ones we need to request.
 			var permissionsToRequest = new List<Permission>();
-			foreach(var permission in permissions)
+			foreach (var permission in permissions)
 			{
 				var permissionStatus = PermissionStatus.Unknown;
-				switch(permission)
+				switch (permission)
 				{
 					case Permission.Camera:
 						permissionStatus = await CrossPermissions.Current.CheckPermissionStatusAsync<CameraPermission>();
@@ -569,7 +556,7 @@ namespace Plugin.Media
 
 				if (permissionStatus != PermissionStatus.Granted)
 					permissionsToRequest.Add(permission);
-            }
+			}
 
 			//Nothing to request, Awesome!
 			if (permissionsToRequest.Count == 0)
@@ -599,16 +586,16 @@ namespace Plugin.Media
 
 			//Gunna need those permissions :(
 			throw new MediaPermissionException(notGranted.Select(r => r.Key).ToArray());
-			
-        }
+
+		}
 
 		const string cameraDescription = "NSCameraUsageDescription";
 		const string photoDescription = "NSPhotoLibraryUsageDescription";
 		const string photoAddDescription = "NSPhotoLibraryAddUsageDescription";
 		const string microphoneDescription = "NSMicrophoneUsageDescription";
 		void CheckUsageDescription(params string[] descriptionNames)
-        {
-			foreach(var description in descriptionNames)
+		{
+			foreach (var description in descriptionNames)
 			{
 
 				var info = NSBundle.MainBundle.InfoDictionary;
@@ -621,5 +608,5 @@ namespace Plugin.Media
 
 			}
 		}
-    }
+	}
 }

--- a/src/Media.Plugin/iOS/MediaPickerDelegate.cs
+++ b/src/Media.Plugin/iOS/MediaPickerDelegate.cs
@@ -47,12 +47,8 @@ namespace Plugin.Media
 		
 		public Task<List<MediaFile>> Task => tcs.Task;
 
-		private bool isFinished;
 		public override async void FinishedPickingMedia(UIImagePickerController picker, NSDictionary info)
 		{
-			if (isFinished)
-				return;
-			isFinished = true;
 			RemoveOrientationChangeObserverAndNotifications();
 
 			MediaFile mediaFile;
@@ -81,7 +77,6 @@ namespace Plugin.Media
                     tcs.SetException(new FileNotFoundException());
 				else
 					tcs.TrySetResult(new List<MediaFile> { mediaFile });
-				isFinished = false;
 			});
 		}
 
@@ -132,7 +127,7 @@ namespace Plugin.Media
 				if (IsValidInterfaceOrientation(UIDevice.CurrentDevice.Orientation))
 					orientation = UIDevice.CurrentDevice.Orientation;
 				else
-					orientation = getDeviceOrientation(viewController.InterfaceOrientation);
+					orientation = GetDeviceOrientation(viewController.InterfaceOrientation);
 			}
 
 			double x, y;
@@ -397,7 +392,7 @@ namespace Plugin.Media
 			if (!savedImage)
 			{
 				var finalQuality = quality;
-				var imageData = pathExtension == "jpg" ? image.AsJPEG(finalQuality) : image.AsPNG();
+				var imageData = pathExtension == "png" ? image.AsPNG() : image.AsJPEG(finalQuality);
 
 				//continue to move down quality , rare instances
 				while (imageData == null && finalQuality > 0)
@@ -480,7 +475,7 @@ namespace Plugin.Media
 			{
 				pathExtension = pathExtension.ToLowerInvariant();
 				var finalQuality = quality;
-				var imageData = pathExtension == "jpg" ? image.AsJPEG(finalQuality) : image.AsPNG();
+				var imageData = pathExtension == "png" ? image.AsPNG(): image.AsJPEG(finalQuality);
 
 				//continue to move down quality , rare instances
 				while (imageData == null && finalQuality > 0)
@@ -497,10 +492,10 @@ namespace Plugin.Media
 				using var newImageSource = ciImage.CreateBySettingProperties(meta);
 				using var ciContext = new CIContext();
 
-				if (pathExtension == "jpg")
-					return ciContext.WriteJpegRepresentation(newImageSource, NSUrl.FromFilename(path), CGColorSpace.CreateSrgb(), new NSDictionary(), out var error);
+				if (pathExtension == "png")
+					return ciContext.WritePngRepresentation(newImageSource, NSUrl.FromFilename(path), CIFormat.ARGB8, CGColorSpace.CreateSrgb(), new NSDictionary(), out var error2);
 				
-				return ciContext.WritePngRepresentation(newImageSource, NSUrl.FromFilename(path), CIFormat.ARGB8, CGColorSpace.CreateSrgb(), new NSDictionary(), out var error2);
+				return ciContext.WriteJpegRepresentation(newImageSource, NSUrl.FromFilename(path), CGColorSpace.CreateSrgb(), new NSDictionary(), out var error);
 			}
 			catch (Exception ex)
 			{
@@ -519,7 +514,7 @@ namespace Plugin.Media
 			{
 				pathExtension = pathExtension.ToLowerInvariant();
 				var finalQuality = quality;
-				var imageData = pathExtension == "jpg" ? image.AsJPEG(finalQuality) : image.AsPNG();
+				var imageData = pathExtension == "png" ? image.AsPNG() : image.AsJPEG(finalQuality);
 
 				//continue to move down quality , rare instances
 				while (imageData == null && finalQuality > 0)
@@ -684,6 +679,7 @@ namespace Plugin.Media
 
 		internal static string GetOutputPath(string type, string path, string name, string extension, long index = 0)
 		{
+			extension = extension.ToLowerInvariant();
 			path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), path);
 			Directory.CreateDirectory(path);
 
@@ -693,7 +689,7 @@ namespace Plugin.Media
 			if (string.IsNullOrWhiteSpace(name))
 			{
 				if (type == MediaImplementation.TypeImage)
-					name = extension == "jpg" ? $"IMG_{postpendName}.jpg" : $"IMG_{postpendName}.png";
+					name = extension == "png" ? $"IMG_{postpendName}.png" : $"IMG_{postpendName}.jpg";
 				else
 					name = $"VID_{postpendName}.{extension ?? "mp4"}";
 			}
@@ -727,7 +723,7 @@ namespace Plugin.Media
 			return false;
 		}
 
-		private static UIDeviceOrientation getDeviceOrientation(UIInterfaceOrientation self)
+		private static UIDeviceOrientation GetDeviceOrientation(UIInterfaceOrientation self)
 		{
 			switch (self)
 			{
@@ -826,7 +822,7 @@ namespace Plugin.Media
 
 			pathExtension = pathExtension.ToLowerInvariant();
 			var finalQuality = pathExtension == "jpg" ? (compressionQuality / 100f) : 0f;
-			var imageData = pathExtension == "jpg" ? imageToReturn.AsJPEG(finalQuality) : imageToReturn.AsPNG();
+			var imageData = pathExtension == "png" ? imageToReturn.AsPNG() : imageToReturn.AsJPEG(finalQuality);
 			//continue to move down quality , rare instances
 			while (imageData == null && finalQuality > 0)
 			{


### PR DESCRIPTION
Added missing meta-data when picking multiple image with PickPhotosAsync().

Fixes  #747 for good.

Changes Proposed in this pull request:
- When PNG is detected, use PNG in all code paths.
- IEIC format is treated as JPEG, not PNG.
- Meta data is handled correctly when picking via PickPhotosAsync.

Tested with both JPG and PNG images on iOS 13.3.

I apparently have used format document in some of the files, which has made the PR a bit unwieldy, at least when viewed on GitHub, not so much when viewed in VS - sorry for that.