### PR TITLE
Completion condition fix in OnDestroy method for Android

### DIFF
--- a/src/Media.Plugin/Android/MediaPickerActivity.cs
+++ b/src/Media.Plugin/Android/MediaPickerActivity.cs
@@ -651,7 +651,7 @@ namespace Plugin.Media
 		/// </summary>
         protected override void OnDestroy()
         {
-            if(!completed)
+            if(completed)
             {
                 DeleteOutputFile();
 				MediaImplementation.CompletionSource = null;


### PR DESCRIPTION
Completion condition is invalid: MediaPickerActivity lifecycle didn't hit OnActivityResult yet if OnDestroy is called. That's why when the actual OnActivityResult call performs (after OnDestroy), we don't have MediaPicked event subscription, and the handler method would never be called.