### PR TITLE
Fix crash on double cancel

### DIFF
--- a/src/Media.Plugin/iOS/MediaPickerDelegate.cs
+++ b/src/Media.Plugin/iOS/MediaPickerDelegate.cs
@@ -41,7 +41,7 @@ namespace Plugin.Media
 			set;
 		}
 
-		public void CancelTask() => tcs.SetResult(null);
+		public void CancelTask() => tcs.TrySetResult(null);
 
 		public UIView View => viewController.View;
 		
@@ -91,7 +91,7 @@ namespace Plugin.Media
 
 			Dismiss(picker, () =>
 			{
-				tcs.SetResult(null);
+				tcs.TrySetResult(null);
 			});
 		}
 
@@ -106,7 +106,7 @@ namespace Plugin.Media
 
 			Dismiss(picker, () =>
 			{
-				tcs.SetResult(null);
+				tcs.TrySetResult(null);
 			});
 		}
 


### PR DESCRIPTION
This fixes a crash we encountered in production, apparently related to multiple quickly occurring cancel-related events.

```
Application Specific Information:
*** Terminating app due to uncaught exception 'SIGABRT', reason: 'System.InvalidOperationException'

Xamarin Exception Stack:
System.InvalidOperationException: 
  at System.Threading.Tasks.TaskCompletionSource`1[TResult].SetResult (TResult result) <0x10307025c + 0x00033> in <624bcc4ce53347508a7b8fa821d78da4#abd305c4a04020432f73574d8c888ba2>:0
  at Plugin.Media.MediaPickerDelegate.<Canceled>b__12_0 () <0x104c43ef8 + 0x00013> in <bca0256229394a65ac3cb60c690728de#abd305c4a04020432f73574d8c888ba2>:0
  at ObjCRuntime.Trampolines+SDAction.Invoke (System.IntPtr block) <0x103c91984 + 0x00053> in <698888335fd24bdca1317448cda6f409#abd305c4a04020432f73574d8c888ba2>:0
  at (wrapper native-to-managed) ObjCRuntime.Trampolines+SDAction.Invoke(intptr)
  at (wrapper managed-to-native) UIKit.UIApplication.UIApplicationMain(int,string[],intptr,intptr)
  at UIKit.UIApplication.Main (System.String[] args, System.IntPtr principal, System.IntPtr delegate) <0x103caefb0 + 0x0003f> in <698888335fd24bdca1317448cda6f409#abd305c4a04020432f73574d8c888ba2>:0
  at UIKit.UIApplication.Main (System.String[] args, System.String principalClassName, System.String delegateClassName) <0x103caef08 + 0x00053> in <698888335fd24bdca1317448cda6f409#abd305c4a04020432f73574d8c888ba2>:0
  at Watertight.Mobile.iOS.Application.Main (System.String[] args) <0x102e63b50 + 0x00033> in <de805017b8654bd581238f713a1a32ce#abd305c4a04020432f73574d8c888ba2>:0
  at null.null
  at (wrapper managed-to-native) UIKit.UIApplication.UIApplicationMain(int,string[],intptr,intptr)
  at UIKit.UIApplication.Main (System.String[] args, System.IntPtr principal, System.IntPtr delegate) <0x103caefb0 + 0x0003f> in <698888335fd24bdca1317448cda6f409#abd305c4a04020432f73574d8c888ba2>:0
  at UIKit.UIApplication.Main (System.String[] args, System.String principalClassName, System.String delegateClassName) <0x103caef08 + 0x00053> in <698888335fd24bdca1317448cda6f409#abd305c4a04020432f73574d8c888ba2>:0
  at [app entry point]
