### PR TITLE
Fixes saving photos to the gallery for Android Q.

### DIFF
--- a/src/Media.Plugin/Android/MediaImplementation.cs
+++ b/src/Media.Plugin/Android/MediaImplementation.cs
@@ -201,6 +201,7 @@ namespace Plugin.Media
                 var fileName = System.IO.Path.GetFileName(media.Path);
                 var uri = MediaPickerActivity.GetOutputMediaFile(context, options.Directory ?? "temp", fileName, true, true);
                 var f = new Java.IO.File(uri.Path);
+                media.AlbumPath = uri.ToString();
 
                 try
                 {


### PR DESCRIPTION
Fixes #875.

@jamesmontemagno I'm upgrading an app to Android Q at the moment, I need the `SaveToAlbum = true` functionality to work there, so I thought I'd have a go at fixing this. This has been tested on a Samsung Galaxy S10, running Android API Level 29. If you could let me know if I'm on the right track here, or if anything else needs to be done, that would be great.
