### PR TITLE
Added locking around the disposal of the observer

### DIFF
--- a/src/Media.Plugin/iOS/MediaPickerDelegate.cs
+++ b/src/Media.Plugin/iOS/MediaPickerDelegate.cs
@@ -154,6 +154,7 @@ namespace Plugin.Media
 
         UIDeviceOrientation? orientation;
         NSObject observer;
+        readonly object observerDisposeLock = new object();
         readonly UIViewController viewController;
         readonly UIImagePickerControllerSourceType source;
         TaskCompletionSource<List<MediaFile>> tcs = new TaskCompletionSource<List<MediaFile>>();
@@ -203,18 +204,24 @@ namespace Plugin.Media
 
             if (observer != null)
             {
-                try
+                lock (observerDisposeLock)
                 {
-                    NSNotificationCenter.DefaultCenter.RemoveObserver(observer);
-                }
-                catch (Exception ex)
-                {
-                    Debug.WriteLine(ex);
-                }
+                    if (observer != null)
+                    {
+                        try
+                        {
+                            NSNotificationCenter.DefaultCenter.RemoveObserver(observer);
+                        }
+                        catch (Exception ex)
+                        {
+                            Debug.WriteLine(ex);
+                        }
 
+                        observer.Dispose();
+                        observer = null;
+                    }
+                }
             }
-            observer?.Dispose();
-            observer = null;
         }
 
         void DidRotate(NSNotification notice)


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes #910 .

Changes Proposed in this pull request:

I cannot confirm whether this solves the issue as I have been unable to reliably reproduce the issue locally. I can confirm that it certainly hasn't made the situation any worse.