### PR TITLE
Added "Exported=false" per Android 12 requirements

### DIFF
--- a/src/Media.Plugin/Android/MediaPickerActivity.cs
+++ b/src/Media.Plugin/Android/MediaPickerActivity.cs
@@ -26,7 +26,7 @@ namespace Plugin.Media
     /// <summary>
     /// Picker
     /// </summary>
-    [Activity(ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize | ConfigChanges.UiMode)]
+    [Activity(Exported=false, ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize | ConfigChanges.UiMode)]
     public class MediaPickerActivity
         : Activity, Android.Media.MediaScannerConnection.IOnScanCompletedListener
     {


### PR DESCRIPTION

Please take a moment to fill out the following:
Per Android 12 requirements: https://developer.android.com/about/versions/12/behavior-changes-12#exported any activity needs to have an "Exported" attributes with true/false value in order to run it on Android 12 device.

Fixes # . 
Changes Proposed in this pull request:
- Added "Exported=false" in MediaPickerActivity.cs
-
- 
